### PR TITLE
ci: switch to unified SonarSource/sonarqube-scan-action@v5

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -45,7 +45,10 @@ jobs:
         run: npm run coverage
 
       - name: SonarCloud scan
-        uses: sonarsource/sonarcloud-github-action@v3
+        # Direct call to the unified Sonar action (cloud + server).
+        # The legacy `sonarsource/sonarcloud-github-action` is itself
+        # a deprecated wrapper that delegates here — we skip the hop.
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

Replaces the deprecated `sonarsource/sonarcloud-github-action` (v3 in master, v5 in #21) with the unified `SonarSource/sonarqube-scan-action@v5` directly.

Both actions are maintained by SonarSource. v5 of the legacy `sonarcloud-github-action` is just a composite wrapper that prints a deprecation warning and delegates to `sonarqube-scan-action@v5.0.0`. Skipping the wrapper:

- removes the deprecation warning from every CI log
- one less indirection (composite action calling another action)
- future-proof against the wrapper being removed entirely

## Why this PR instead of merging #21

#21 bumps the wrapper to its final form. This PR replaces the wrapper. End-state is the same scanner running, but the workflow is on the supported entry point going forward.

## Test plan

- [ ] CI green (build, CodeQL, HACS-validate, SonarCloud scan)
- [ ] SonarCloud dashboard updates with this PR's analysis
- [ ] No deprecation warning in the SonarCloud-job log

## Follow-up

Close #21 (Dependabot's wrapper bump) in favour of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)