### PR TITLE
docs: reflect v1.4.2 quality stack + branch protection

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -241,24 +241,49 @@ the plugin can't render a single label with two different font sizes
 ## Build pipeline
 
 ```
-npm run lint    →  eslint src        (style)
-npm run test    →  vitest run        (361 tests across 12 modules)
-npm run rollup  →  rollup -c         (single dist/weather-station-card.js)
-npm run build   =  lint + test + rollup
+npm run lint       →  eslint src tests-e2e   (ESLint 10 flat-config)
+npm run typecheck  →  tsc --noEmit
+npm run test       →  vitest run             (385 tests across 12 modules)
+npm run depcheck   →  depcruise src          (architecture rules)
+npm run rollup     →  rollup -c              (single dist/weather-station-card.js)
+npm run build      =  lint + typecheck + test + rollup
 ```
 
-CI (`.github/workflows/build.yml`) runs all three on every push, plus:
+CI (`.github/workflows/build.yml`) runs the same chain on every push,
+extended with these gates (since v1.4.2 — issue #19):
 
-- Coverage gate at ≥ 80 % (statements, branches, functions, lines).
+- **Security audit**: `npm audit --audit-level=high` blocks the build
+  on high/critical advisories. Lower-severity findings come as
+  Dependabot PRs (`.github/dependabot.yml`, weekly).
+- **Lint**: ESLint 10 with `typescript-eslint`, `eslint-plugin-lit`,
+  `eslint-plugin-sonarjs`. Zero errors required; complexity warnings
+  tracked as backlog (see `eslint.config.mjs`).
+- **Coverage gate at ≥ 80 %** (statements, branches, functions, lines).
   Configured in `vitest.config.js`. Failing the gate fails the build.
-- Bundle budget at < 800 KB. Tripping signals a regression in
+  Note: pre-v1.4.2 the include array listed `.js` paths after the
+  v1.2 TS migration and matched zero files — the gate was silently
+  inert. Paths are `.ts` now.
+- **Architecture rules**: `dependency-cruiser` enforces no-circular,
+  no-orphans, and module boundaries (`src/chart/`, `src/editor/`,
+  `src/utils/` may not uplevel-import).
+- **Bundle budget at < 800 KB**. Tripping signals a regression in
   tree-shaking or an accidental large dep.
+- **CodeQL** (`security-extended` queries) on every PR + weekly
+  schedule, covering JS/TS security smells ESLint doesn't catch.
+- **SonarCloud** (`.github/workflows/sonarcloud.yml`) reads the
+  Vitest LCOV output and reports Cognitive Complexity, Code Smells,
+  Security Hotspots, and Coverage trend. Not a required check —
+  advisory only so a Sonar outage doesn't block merges.
 - Verifies `dist/weather-station-card.js` is in sync with source.
 - On tag pushes, verifies `package.json` version matches the tag,
   then uploads the bundle as a release asset.
 
 `permissions: contents: write` is set at job level so the release action
 can attach the bundle.
+
+The `master` branch is protected: PRs only, with `build` and
+`Analyze (javascript-typescript)` required-green before merge,
+linear history enforced, force-push and deletion blocked.
 
 ## Distribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,15 +42,35 @@ A missing translation never crashes the card; it just falls through.
 
 ```bash
 npm install
-npm run lint         # eslint over src/
+npm run lint         # ESLint 10 (typescript-eslint + lit + sonarjs)
+npm run typecheck    # tsc --noEmit
 npm run test         # vitest run (see TESTING.md)
+npm run coverage     # vitest with v8 coverage provider
+npm run depcheck     # dependency-cruiser architecture rules
 npm run rollup       # one-shot bundle
-npm run build        # lint + test + bundle
+npm run build        # lint + typecheck + test + rollup
 npm start            # rollup --watch + dev server
 ```
 
 Built artefact: `dist/weather-station-card.js`. **Always commit the rebuilt
 bundle alongside source changes** — HACS serves it directly from the tag.
+
+## CI & branch protection
+
+`master` is protected. Direct pushes are blocked — every change goes
+through a pull request. Two CI checks must be green before the merge
+button activates:
+
+- **`build`** (`.github/workflows/build.yml`) — lint, audit, typecheck,
+  unit tests, coverage gate, depcheck, bundle, e2e + visual regression,
+  bundle-budget, and dist-in-sync verification.
+- **`Analyze (javascript-typescript)`** (CodeQL) — security analysis.
+
+SonarCloud and Dependabot run on PRs too but are advisory; CodeQL's
+`Analyze` job is required, the standalone CodeQL helper check is not.
+
+Linear history is enforced (no merge commits) — the maintainer uses
+`gh pr merge --rebase` to land PRs.
 
 ## Tests
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -36,6 +36,16 @@ lines drops below **80 %** for the modules listed in
 `vitest.config.js`. Editor + main.ts are out of unit-coverage scope
 (rendering paths are exercised by Playwright instead).
 
+Real coverage as of v1.4.2: 90.7 % statements, 80.9 % branches,
+84.2 % functions, 92.8 % lines. `scroll-ux.ts` is the under-threshold
+module (53 % branch); the global aggregate still passes.
+
+> **History note**: pre-v1.4.2 the `include` array in
+> `vitest.config.js` listed `.js` paths after the v1.2 TypeScript
+> migration. The v8 coverage provider matched zero files and the
+> gate was silently inert (`Statements 0/0 (Unknown%)`). Fixed in
+> v1.4.2 — see issue #19.
+
 ## Unit-test layout
 
 ```


### PR DESCRIPTION
## Summary

Public-doc follow-up to v1.4.2 + branch-protection activation. No code changes — brings the three contributor-facing docs in sync with what the pipeline actually does now.

| File | What changed |
|---|---|
| `ARCHITECTURE.md` | "Build pipeline" section: real lint step (was a stub), `depcheck`, `npm audit`, CodeQL, SonarCloud, branch-protection note. Adds the silent-coverage-gate-bug as historical context. |
| `TESTING.md` | "Coverage gate" section: actual coverage numbers (90.7 % stmt / 80.9 % branch / 84.2 % func / 92.8 % line). History note on the `.js`→`.ts` include-path fix. |
| `CONTRIBUTING.md` | "Build & dev workflow": full updated script chain. New "CI & branch protection" section listing required-green checks. |

## Why no version bump

Pure docs. The shipped artefact (`dist/weather-station-card.js`) is unchanged.

## Test plan

- [ ] CI green
- [ ] Markdown renders correctly on GitHub (no broken cross-links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)