### PR TITLE
docs: PR template + Release flow section in CONTRIBUTING

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+Thanks for opening a PR! A few prompts below — none are blocking, they're
+here to make sure nothing falls through the cracks. Delete sections that
+don't apply.
+-->
+
+## Summary
+
+<!-- 1–3 sentences. Link the issue this addresses. -->
+
+## Test plan
+
+<!-- Checklist of what to verify. Examples:
+- [ ] `npm run build` passes locally
+- [ ] New unit test for X covers the regression
+- [ ] Smoke-tested on Pi (Pi setup is in CLAUDE.md)
+-->
+
+- [ ]
+- [ ]
+
+## Documentation impact
+
+If this PR changes any of the below, update the corresponding doc in
+the same PR. If none apply, tick "no docs need updating".
+
+- [ ] No docs need updating
+- [ ] `CHANGELOG.md` — entry under `[Unreleased]` or `[X.Y.Z]`
+- [ ] `README.md` — user-facing config keys, behaviour, screenshots
+- [ ] `ARCHITECTURE.md` — module boundaries, build pipeline, data flow
+- [ ] `TESTING.md` — test layers, coverage scope, e2e baseline procedure
+- [ ] `CONTRIBUTING.md` — dev workflow, build scripts, release flow
+- [ ] `MIGRATION.md` — breaking change requiring user action
+- [ ] `docs/CONFIGURATION.md` / `docs/SENSORS.md` / `docs/CONDITIONS.md` — reference doc affected
+
+## Issues
+
+<!-- Closes #N or Refs #N -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,40 @@ covered (Lit lifecycle, Chart.js drawing, editor DOM). New PRs that touch
 - ES2022 features are fine (`?.`, `??`, top-level await is not used).
 - Inline comments only when the *why* is non-obvious. Don't restate code.
 
+## Release flow
+
+For maintainers cutting a new `vX.Y.Z` release. The build workflow on
+`master` enforces some of these (tag-vs-package.json, CHANGELOG entry
+present, dist in sync); the rest are convention.
+
+1. **Bump version** in `package.json`.
+2. **CHANGELOG entry** — prepend a `## [X.Y.Z] — YYYY-MM-DD` block
+   (format: see [docs/STYLE-GUIDE.md](docs/STYLE-GUIDE.md#changelog-format)).
+   The build workflow extracts this verbatim into the GitHub release
+   body when you push the tag.
+3. **Verify these docs reflect what changed** — a release is a good
+   time to catch doc drift. None of these are mandatory per release,
+   but ask yourself for each:
+   - `README.md` — new user-facing config keys, behaviour, screenshots
+   - `ARCHITECTURE.md` — module boundaries, build pipeline, data flow
+   - `TESTING.md` — test layers, coverage scope
+   - `CONTRIBUTING.md` — dev workflow changes
+   - `MIGRATION.md` — breaking change for users
+4. **`npm run build`** — regenerates `dist/weather-station-card.js`.
+   Commit it together with the source. CI will reject the tag push
+   if `dist/` is out of sync with HEAD.
+5. **Open a PR**, wait for CI green, rebase-merge to `master`.
+   `master` is branch-protected — direct push will fail.
+6. **Tag and push**:
+   ```bash
+   git tag vX.Y.Z master
+   git push origin refs/tags/vX.Y.Z
+   ```
+   The `build` workflow then verifies tag matches `package.json.version`,
+   extracts the `[X.Y.Z]` block from `CHANGELOG.md` as release notes,
+   and uploads `dist/weather-station-card.js` to the GitHub release —
+   HACS picks it up automatically.
+
 ## Issues
 
 Bugs, feature requests, and questions:


### PR DESCRIPTION
## Summary

Two low-friction nudges so docs stay in sync with code over time. Follow-up to PR #28 (which synchronised the existing docs to v1.4.2 reality) — this PR adds the *mechanism* that should keep them synchronised going forward.

## Test plan

- [ ] CI green
- [ ] PR template renders correctly when opening any new PR (will be visible on the next PR after merge)
- [ ] CONTRIBUTING.md "Release flow" section renders correctly on GitHub

## What changes

### `.github/PULL_REQUEST_TEMPLATE.md` (new)

Every new PR now gets pre-populated with three sections: Summary, Test plan, Documentation impact. The Documentation impact section is a checklist of every doc that might need updating, with "no docs need updating" as the default option. Friction near zero for bug-fix PRs; visual reminder for PRs that *do* affect docs.

### `CONTRIBUTING.md` — new "Release flow" section

Formalises the maintainer release procedure that was previously only in the gitignored `CLAUDE.md`:

1. Bump version
2. CHANGELOG entry
3. Doc-drift check (README, ARCHITECTURE, TESTING, CONTRIBUTING, MIGRATION)
4. `npm run build` + commit dist
5. PR + rebase-merge
6. Tag push triggers HACS release

## Why no CI gate

Considered a workflow that would compare source-diff vs. doc-diff and fail PRs touching `src/` without touching docs. Rejected: ~80% of bug-fix PRs would false-fire and the gate would get disabled or ignored within a week. Better to keep the gate quiet and the human alert.

## Documentation impact

- [ ] No docs need updating
- [x] `CONTRIBUTING.md` — new "Release flow" section

(Self-application of the very template introduced here. Meta but appropriate.)

## Issues

Refs #19 (parent quality-tooling initiative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)