### PR TITLE
docs: write CHANGELOG entries for HACS users, not engineers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,12 @@ present, dist in sync); the rest are convention.
 2. **CHANGELOG entry** — prepend a `## [X.Y.Z] — YYYY-MM-DD` block
    (format: see [docs/STYLE-GUIDE.md](docs/STYLE-GUIDE.md#changelog-format)).
    The build workflow extracts this verbatim into the GitHub release
-   body when you push the tag.
+   body when you push the tag, and HACS shows that body in its in-app
+   update dialog. **Write for that reader, not for engineers**: plain
+   user-perspective English, lead with the user impact, keep
+   build/tooling detail in a short "Under the hood" section. If a
+   release has no user-facing changes, say so plainly in one sentence
+   and stop — don't pad with internal jargon.
 3. **Verify these docs reflect what changed** — a release is a good
    time to catch doc drift. None of these are mandatory per release,
    but ask yourself for each:

--- a/docs/STYLE-GUIDE.md
+++ b/docs/STYLE-GUIDE.md
@@ -175,26 +175,69 @@ All images carry meaningful `alt` text.
 
 ## CHANGELOG format
 
-Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and SemVer. Header:
+Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and SemVer.
+
+### Audience
+
+The CHANGELOG entry is **not** an engineering log. The release workflow
+uploads it verbatim as the GitHub release body, and HACS shows that body
+inside its in-app update dialog. The reader is a dashboard owner deciding
+whether to click *Update* — not a future maintainer reading git history.
+They don't know what ESLint, dependency-cruiser, or `vitest.config.js`
+are, and they shouldn't have to.
+
+Write for that reader. Plain user-perspective English, lead with what
+the user gains or has to do (re-configure, clear cache, update YAML, …).
+
+### Voice
+
+- **Lead with impact, not mechanism.** "Hourly chart now scrolls smoothly
+  on touch devices" is the headline; *how* it was achieved (rAF
+  coalescing, label cache, …) is at most a parenthetical.
+- **No tool names** unless directly relevant to the user. ESLint,
+  dependency-cruiser, vitest, sonarjs, CodeQL, etc. belong in commit
+  messages and PRs.
+- **No file paths.** `src/main.ts`, `chart/styles.ts` are noise to the
+  user.
+- **No internal metrics.** Coverage percentages, lint-warning counts,
+  threshold numbers, bundle-byte deltas — all internal.
+- **No multi-paragraph rationale.** Link the issue / PR instead.
+
+### Structure
 
 ```markdown
 ## [X.Y.Z] — YYYY-MM-DD
 
-[1-line release theme]
+[1–2 sentences answering "what does this mean for me?" — what's new
+or better, and whether the user needs to do anything. If there are
+no user-facing changes, say exactly that in one plain sentence and
+keep the rest of the entry short — don't pad with tooling detail.]
 
 ### Added
-- ...
+- [User-visible new capability, in their words.]
 ### Changed
-- ...
+- [User-visible behaviour difference. Mention the mechanism only if
+  it helps the user understand a trade-off.]
 ### Fixed
-- ...
+- [What was broken from the user's perspective; what's fixed now.]
 ### Removed
 - ...
 ### Deprecated
 - ...
+### Under the hood
+- [Internal cleanup, build/CI work, refactors with zero user-facing
+  effect. One short line each. If the whole release is internal,
+  this is the only section after the lead.]
 ### Deferred to vX.Y+1
 - ...
 ```
+
+### The "would they click Update?" test
+
+Before committing the entry, re-read it as a HACS user seeing it in the
+update dialog with no other context. Can they tell whether the update
+affects them and whether they need to do anything? If the answer is
+"no, they'd just be confused by the jargon", rewrite.
 
 Reference issues / PRs as `(#123)` or full URL on first mention.
 


### PR DESCRIPTION
## Summary

The CHANGELOG entry is uploaded verbatim as the GitHub release body, and HACS displays that body inside its in-app update dialog. The current guidance produced release notes dominated by build-tooling detail (ESLint flat-config, dependency-cruiser rules, vitest path globs, coverage percentages) — none of which a dashboard owner clicking *Update* needs to read.

This PR updates `docs/STYLE-GUIDE.md` and `CONTRIBUTING.md` to make the audience explicit and prescribe a user-perspective voice, in effect from the next release.

- **Audience block** in the style guide: the reader is the HACS update-dialog viewer, not a future maintainer.
- **Voice rules**: lead with user impact, not mechanism. No tool names, file paths, internal metrics, or multi-paragraph rationale in the entry — those belong in commits and PRs.
- **New `Under the hood` section** for cleanup / build / CI work with no user-facing effect. If the whole release is internal, the lead sentence plus that section is the entire entry.
- **"Would they click Update?" test** before committing the entry.
- `CONTRIBUTING.md` release-flow Step 2 reinforces the audience point right where the maintainer writes the entry.

No retroactive rewrite of v1.4.2.

## Test plan

- [ ] CI green (build + CodeQL).
- [ ] Next release (v1.4.3 or v1.5.0) follows the new structure: lead with user impact, internal work in `Under the hood`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)