### PR TITLE
docs: collapse <picture> blocks in README hero table for mobile rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,24 +60,9 @@ forecast — driven by sensor data, not a `weather.*` entity.
 <th>Visual editor</th>
 </tr>
 <tr>
-<td>
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="tests-e2e/snapshots/render-modes.spec.ts/daily-combination-sunshine-dark.png" />
-    <img alt="Daily combination with sunshine" src="tests-e2e/snapshots/render-modes.spec.ts/daily-combination-sunshine.png" />
-  </picture>
-</td>
-<td>
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="tests-e2e/snapshots/render-modes.spec.ts/daily-station-sunshine-dark.png" />
-    <img alt="Daily station-only chart with sunshine" src="tests-e2e/snapshots/render-modes.spec.ts/daily-station-sunshine.png" />
-  </picture>
-</td>
-<td>
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="tests-e2e/snapshots/editor-visual.spec.ts/editor-dark.png" />
-    <img alt="Visual editor" src="tests-e2e/snapshots/editor-visual.spec.ts/editor.png" />
-  </picture>
-</td>
+<td><picture><source media="(prefers-color-scheme: dark)" srcset="tests-e2e/snapshots/render-modes.spec.ts/daily-combination-sunshine-dark.png"><img alt="Daily combination with sunshine" src="tests-e2e/snapshots/render-modes.spec.ts/daily-combination-sunshine.png"></picture></td>
+<td><picture><source media="(prefers-color-scheme: dark)" srcset="tests-e2e/snapshots/render-modes.spec.ts/daily-station-sunshine-dark.png"><img alt="Daily station-only chart with sunshine" src="tests-e2e/snapshots/render-modes.spec.ts/daily-station-sunshine.png"></picture></td>
+<td><picture><source media="(prefers-color-scheme: dark)" srcset="tests-e2e/snapshots/editor-visual.spec.ts/editor-dark.png"><img alt="Visual editor" src="tests-e2e/snapshots/editor-visual.spec.ts/editor.png"></picture></td>
 </tr>
 </table>
 


### PR DESCRIPTION
## Summary

The hero screenshot table used multi-line, indented `<picture>`/`<source>`/`<img>` blocks inside `<td>` cells. GitHub's mobile-web sanitizer is stricter than the desktop renderer and bails out, displaying the raw `<picture>` and `<source>` tags as text next to the actual image.

**Fix:** collapse each cell's `<picture>` onto a single line and drop the self-closing `/>` on void elements (HTML5-conformant). Dark-mode variants preserved.

Verified via `gh api repos/.../readme -H "Accept: application/vnd.github.html"` that desktop rendering was already correct (`<themed-picture><picture>...</picture></themed-picture>`); the change is purely a mobile-renderer compatibility fix. README-only — no code touched.

## Test plan

- [ ] Open the README on github.com on a desktop browser — hero table renders three image columns as before
- [ ] Open the README on the GitHub mobile app (or narrow the desktop browser) — hero images render correctly without raw `<picture>` / `<source>` text leaking through
- [ ] Dark-mode variant kicks in when the OS theme is dark