### PR TITLE
fix(sonar): mirror vitest coverage scope (#42)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -30,3 +30,20 @@ sonar.exclusions=dist/**,node_modules/**,coverage/**,playwright-report/**,test-r
 # main.ts uses @ts-nocheck per architecture decision (HA integration
 # boundary). Mirror that here so SonarCloud doesn't double-report.
 sonar.javascript.exclusions=src/main.ts
+
+# Coverage scope must mirror vitest.config.js `coverage.include`. The
+# unit-tested modules listed there feed into coverage/lcov.info; the
+# files below are exercised only by Playwright E2E (#14) which doesn't
+# pipe coverage to lcov, so Sonar would otherwise count them as 100 %
+# uncovered and the dashboard reports ~77 % line coverage instead of
+# the real ~92 %. Keep this list in sync with vitest.config.js when
+# files move between unit and E2E coverage. (Tracked in #42.)
+sonar.coverage.exclusions=\
+  src/main.ts,\
+  src/const.ts,\
+  src/locale.ts,\
+  src/weather-station-card-editor.ts,\
+  src/editor/**,\
+  src/chart/draw.ts,\
+  src/chart/orchestrator.ts,\
+  src/chart/styles.ts


### PR DESCRIPTION
## Summary

SonarCloud reported 77.6 % line coverage while local Vitest reports 92.8 %. Branch coverage matched (80.9 %), so the lcov upload itself was working — the cause was a scope mismatch:

- `sonar.sources=src` told Sonar to analyse the entire `src/` tree (25 .ts files, minus the `main.ts` exclusion = 24 files).
- `vitest.config.js` `coverage.include` only feeds 12 files into `coverage/lcov.info` — the rest are exercised by Playwright E2E (#14) which doesn't pipe coverage data.

The 13 unmeasured files (\`editor/**\`, \`chart/draw.ts\`, \`chart/orchestrator.ts\`, \`chart/styles.ts\`, \`weather-station-card-editor.ts\`, \`const.ts\`, \`locale.ts\`) were counted by Sonar as fully uncovered, dragging the dashboard line-coverage from ~92 % down to ~78 %.

## Fix

Add \`sonar.coverage.exclusions\` listing exactly the files Vitest doesn't measure. Comment in the file points back at \`vitest.config.js\` so future maintainers know the two lists must stay aligned (cross-file invariant).

## Test plan

- [x] Diff inspected — single config-only addition, no source change
- [ ] CI green
- [ ] Post-merge: SonarCloud line-coverage moves from 77.6 % → ~92 % on next scan (verify on dashboard)

Closes #42.