### PR TITLE
fix: annotate 7 deliberately silent catch blocks (#41)

### DIFF
--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -597,7 +597,11 @@ export class ForecastDataSource {
     try {
       const unsub = await pending;
       if (typeof unsub === 'function') unsub();
-    } catch (_) { /* already gone or never landed */ }
+    } catch (err) {
+      // Pending subscribe rejected or already disposed — either way the
+      // resource is gone, no further teardown to do.
+      void err;
+    }
   }
 
   private _resubscribe(): void {
@@ -605,7 +609,15 @@ export class ForecastDataSource {
       const pending = this._unsubPromise;
       this._unsubPromise = null;
       pending.then(
-        (unsub) => { try { if (typeof unsub === 'function') unsub(); } catch (_) { /* ignore */ } },
+        (unsub) => {
+          try {
+            if (typeof unsub === 'function') unsub();
+          } catch (err) {
+            // Disposing a previous subscription that already errored —
+            // nothing actionable for the caller mid-resubscribe.
+            void err;
+          }
+        },
         () => { /* rejected — nothing to dispose */ },
       );
     }

--- a/src/openmeteo-source.ts
+++ b/src/openmeteo-source.ts
@@ -155,7 +155,10 @@ function loadFromStorage(storage: StorageLike | null, lat: number, lon: number):
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== 'object') return null;
     return parsed as CachedPayload;
-  } catch (_) {
+  } catch (err) {
+    // Storage access blocked or JSON corrupted — fall through to a
+    // fresh fetch instead of letting the read failure propagate.
+    void err;
     return null;
   }
 }
@@ -164,7 +167,11 @@ function saveToStorage(storage: StorageLike | null, lat: number, lon: number, pa
   if (!storage) return;
   try {
     storage.setItem(storageKey(lat, lon), JSON.stringify(payload));
-  } catch (_) { /* quota / private-mode — silent */ }
+  } catch (err) {
+    // Quota exceeded or private-mode storage rejection — the cache
+    // write is best-effort; silent failure is correct here.
+    void err;
+  }
 }
 
 /** Read the cached daily array and count past vs forecast days. Used
@@ -293,7 +300,13 @@ export class OpenMeteoSunshineSource {
   /** Abort any in-flight fetch — call this on `disconnectedCallback`. */
   abort(): void {
     if (this._abort) {
-      try { this._abort.abort(); } catch (_) { /* aborted twice */ }
+      try {
+        this._abort.abort();
+      } catch (err) {
+        // AbortController.abort() is idempotent in modern browsers but
+        // older polyfills may throw on a second call — safe to swallow.
+        void err;
+      }
       this._abort = null;
     }
   }

--- a/src/scroll-ux.ts
+++ b/src/scroll-ux.ts
@@ -97,7 +97,13 @@ export function setupScrollUx(card: ScrollUxCard): void {
     startX = ev.clientX;
     startScrollLeft = wrapper.scrollLeft;
     if (ev.pointerType === 'mouse') {
-      try { wrapper.setPointerCapture(ev.pointerId); } catch (_) { /* not always supported */ }
+      try {
+        wrapper.setPointerCapture(ev.pointerId);
+      } catch (err) {
+        // setPointerCapture is gated by browser support for pointer
+        // events; older WebViews throw — drag still works without it.
+        void err;
+      }
     }
   };
 
@@ -332,7 +338,10 @@ export function updateScrollDateStamps(
         date: d.toLocaleDateString(lang, { day: 'numeric', month: 'short' }),
         isMidnight,
       };
-    } catch (_) {
+    } catch (err) {
+      // Malformed datetime in the forecast entry — fall back to empty
+      // labels rather than letting one bad bucket break the chart.
+      void err;
       return { date: '', isMidnight: false };
     }
   };


### PR DESCRIPTION
## Summary

SonarCloud rule \`typescript:S2486\` flagged 7 catch blocks as silently swallowing exceptions. Each is a deliberate fire-and-forget at a documented failure mode — logging would only produce noise on normal degraded-environment paths.

| File | Line | Failure mode |
|---|---|---|
| \`data-source.ts\` | 600 | Pending subscribe rejected or already disposed |
| \`data-source.ts\` | 608 | Disposing a previous subscription that errored |
| \`openmeteo-source.ts\` | 158 | localStorage corrupted / blocked → fresh fetch |
| \`openmeteo-source.ts\` | 167 | localStorage quota or private-mode rejection |
| \`openmeteo-source.ts\` | 296 | \`AbortController.abort()\` called twice |
| \`scroll-ux.ts\` | 100 | \`setPointerCapture\` not supported |
| \`scroll-ux.ts\` | 335 | Malformed datetime in forecast entry |

## Approach

Per #41 user decision (Option B): rename catch parameter \`_\` → \`err\`, add \`void err;\` as the discard statement, and expand the comment to document *why* swallowing is correct at each site. No \`console.debug\` because all 7 are expected normal failure paths — logging would noise.

## Test plan

- [x] \`npm run typecheck\` green
- [x] \`npm run test\` green (385/385)
- [x] \`npm run build\` green
- [x] \`dist/weather-station-card.js\` byte-identical (bundler tree-shakes the \`void err;\` expressions)
- [ ] CI green
- [ ] Post-merge: 7× S2486 findings drop from SonarCloud baseline

Closes #41.