### PR TITLE
chore(deps): drop deprecated @types/chart.js stub (closes #24)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@playwright/test": "^1.59.1",
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.3.0",
-    "@types/chart.js": "^2.9.41",
     "@vitest/coverage-v8": "^4.1.5",
     "dependency-cruiser": "^17.4.0",
     "eslint": "^10.3.0",


### PR DESCRIPTION
## Summary

\`@types/chart.js@2.9.41\` was a leftover from before the v0.7 chart.js v3 → v4 upgrade. chart.js 4.x bundles its own TypeScript definitions (\`./dist/types.d.ts\` exports entry), so the stub package is no longer required.

The package itself is officially deprecated by DefinitelyTyped:

> "This is a stub types definition. chart.js provides its own type definitions, so you do not need this installed."

Dependabot opened #24 to bump it to ^4.0.1 — also a deprecation stub. The cleaner outcome is to **remove the stub entirely**, which is what this PR does.

## Why this is safe

No source imports \`@types/chart.js\`. The three runtime importers (\`main.ts\`, \`chart/draw.ts\`, \`chart/orchestrator.ts\`) all reference \`'chart.js'\` directly, picking up the bundled types via the \`exports.types\` field in chart.js's \`package.json\`.

## Test plan

- [x] \`npm run typecheck\` green
- [x] \`npm run test\` 411/411 green
- [x] \`npm run build\` green
- [ ] CI green
- [ ] Dependabot's PR #24 auto-closes once this merges (or close it manually if not)

Closes #24.