### PR TITLE
docs: absolute raw.githubusercontent URLs for HACS info-panel rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="images/logo.svg" alt="Weather Station Card logo" width="160" />
+  <img src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/images/logo.svg" alt="Weather Station Card logo" width="160" />
 </p>
 
 <h1 align="center">Weather Station Card</h1>
@@ -60,9 +60,9 @@ forecast — driven by sensor data, not a `weather.*` entity.
 <th>Visual editor</th>
 </tr>
 <tr>
-<td><picture><source media="(prefers-color-scheme: dark)" srcset="tests-e2e/snapshots/render-modes.spec.ts/daily-combination-sunshine-dark.png"><img alt="Daily combination with sunshine" src="tests-e2e/snapshots/render-modes.spec.ts/daily-combination-sunshine.png"></picture></td>
-<td><picture><source media="(prefers-color-scheme: dark)" srcset="tests-e2e/snapshots/render-modes.spec.ts/daily-station-sunshine-dark.png"><img alt="Daily station-only chart with sunshine" src="tests-e2e/snapshots/render-modes.spec.ts/daily-station-sunshine.png"></picture></td>
-<td><picture><source media="(prefers-color-scheme: dark)" srcset="tests-e2e/snapshots/editor-visual.spec.ts/editor-dark.png"><img alt="Visual editor" src="tests-e2e/snapshots/editor-visual.spec.ts/editor.png"></picture></td>
+<td><img alt="Daily combination with sunshine" src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/tests-e2e/snapshots/render-modes.spec.ts/daily-combination-sunshine.png"></td>
+<td><img alt="Daily station-only chart with sunshine" src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/tests-e2e/snapshots/render-modes.spec.ts/daily-station-sunshine.png"></td>
+<td><img alt="Visual editor" src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/tests-e2e/snapshots/editor-visual.spec.ts/editor.png"></td>
 </tr>
 </table>
 
@@ -124,9 +124,9 @@ is the default style (`style2`, without boxes), bottom row is
 <td><sub>style 2 (default, no boxes)</sub></td>
 </tr>
 <tr>
-<td><img alt="Combination, style 2" src="tests-e2e/snapshots/styles-grid.spec.ts/combination-style2.png" /></td>
-<td><img alt="Station, style 2" src="tests-e2e/snapshots/styles-grid.spec.ts/station-style2.png" /></td>
-<td><img alt="Forecast, style 2" src="tests-e2e/snapshots/styles-grid.spec.ts/forecast-style2.png" /></td>
+<td><img alt="Combination, style 2" src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/tests-e2e/snapshots/styles-grid.spec.ts/combination-style2.png" /></td>
+<td><img alt="Station, style 2" src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/tests-e2e/snapshots/styles-grid.spec.ts/station-style2.png" /></td>
+<td><img alt="Forecast, style 2" src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/tests-e2e/snapshots/styles-grid.spec.ts/forecast-style2.png" /></td>
 </tr>
 <tr>
 <td><sub>style 1 (with boxes)</sub></td>
@@ -134,9 +134,9 @@ is the default style (`style2`, without boxes), bottom row is
 <td><sub>style 1 (with boxes)</sub></td>
 </tr>
 <tr>
-<td><img alt="Combination, style 1" src="tests-e2e/snapshots/styles-grid.spec.ts/combination-style1.png" /></td>
-<td><img alt="Station, style 1" src="tests-e2e/snapshots/styles-grid.spec.ts/station-style1.png" /></td>
-<td><img alt="Forecast, style 1" src="tests-e2e/snapshots/styles-grid.spec.ts/forecast-style1.png" /></td>
+<td><img alt="Combination, style 1" src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/tests-e2e/snapshots/styles-grid.spec.ts/combination-style1.png" /></td>
+<td><img alt="Station, style 1" src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/tests-e2e/snapshots/styles-grid.spec.ts/station-style1.png" /></td>
+<td><img alt="Forecast, style 1" src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/tests-e2e/snapshots/styles-grid.spec.ts/forecast-style1.png" /></td>
 </tr>
 </table>
 


### PR DESCRIPTION
## Summary

- HACS' info-panel markdown sanitizer drops `<picture>`/`<source>` and won't resolve relative image paths. The README's logo, three hero screenshots, and six modes×styles screenshots all rendered as raw text + alt-only fallbacks on a live HACS install of v1.6.0.
- Switch all 10 in-repo image refs in `README.md` to absolute `https://raw.githubusercontent.com/.../master/...` URLs and drop the `<picture>` wrappers from the three hero `<td>` cells.
- Trade-off: GitHub loses the dark-mode hero variant that #5fd77dc preserved. Repo cover only — HACS info is the higher-traffic surface and was the broken one.

Slated to land on `master` before the **v1.7.0** tag push so HACS users see correct images on the v1.7.0 info-panel.

## Test plan

- [ ] CI green (`build`, `Analyze (javascript-typescript)`).
- [ ] PR's README preview on github.com — three hero images, six modes×styles images, and logo render normally on desktop.
- [ ] Same on github.com mobile web — no raw `<picture>` text leak (regression guard for #5fd77dc).
- [ ] After merge, in HA → HACS → Weather Station Card repository info panel: logo + all README screenshots load (currently broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)