### PR TITLE
test(openmeteo-source): cover silent-catch fallbacks (#56 partial)

### DIFF
--- a/tests/openmeteo-source.test.js
+++ b/tests/openmeteo-source.test.js
@@ -378,6 +378,48 @@ describe('OpenMeteoSunshineSource', () => {
     await p;
     expect(listener).not.toHaveBeenCalled();
   });
+
+  it('survives a getItem that throws (corrupted-storage path, #56 coverage)', () => {
+    // Storage that always throws on read — covers the loadFromStorage
+    // catch branch.
+    const throwingStorage = {
+      getItem: () => { throw new Error('storage corrupted'); },
+      setItem: () => {},
+    };
+    expect(() => new OpenMeteoSunshineSource({
+      latitude: lat, longitude: lon,
+      fetchImpl: vi.fn(() => Promise.reject(new Error('no fetch'))),
+      storage: throwingStorage, now,
+    })).not.toThrow();
+  });
+
+  it('survives a setItem that throws (quota / private-mode path, #56 coverage)', async () => {
+    const throwingStorage = {
+      getItem: () => null,
+      setItem: () => { throw new Error('quota exceeded'); },
+    };
+    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({
+      daily: { time: ['2026-05-21'], sunshine_duration: [50000] },
+    })));
+    const src = new OpenMeteoSunshineSource({
+      latitude: lat, longitude: lon, fetchImpl: fetchSpy, storage: throwingStorage, now,
+    });
+    src.setListener(vi.fn());
+    await expect(src.ensureFresh()).resolves.not.toThrow();
+  });
+
+  it('abort() is safe when AbortController.abort() throws (older-polyfill path, #56 coverage)', () => {
+    const src = new OpenMeteoSunshineSource({
+      latitude: lat, longitude: lon,
+      fetchImpl: vi.fn(() => new Promise(() => {})), // never-resolving
+      storage: makeStorage(), now,
+    });
+    src.setListener(vi.fn());
+    void src.ensureFresh();
+    // Stub the in-flight controller so its abort() throws.
+    src._abort = { abort: () => { throw new Error('double abort'); } };
+    expect(() => src.abort()).not.toThrow();
+  });
 });
 
 describe('readCachedAvailability', () => {


### PR DESCRIPTION
## Summary

Closes 3 of 4 SonarCloud-flagged uncovered new lines in \`openmeteo-source.ts\` by adding tests for the deliberately-silent error handlers introduced in v1.5 (#41):

- \`loadFromStorage\` catch (corrupt cache JSON / blocked storage)
- \`saveToStorage\` catch (quota exceeded / private-mode rejection)
- \`abort()\` catch (older AbortController polyfills throwing on double-abort)

## Coverage delta

| File | Before | After |
|---|---|---|
| \`src/openmeteo-source.ts\` line | 96.42 % | **100 %** |
| All files line | 95.23 % | 95.58 % |
| Branch | 74.6 % (unchanged) | 74.6 % |

## Remaining (deferred to separate PR)

\`#56\` also lists 8 new uncovered lines in \`data-source.ts\` and 1 in \`scroll-ux.ts\`:
- The \`data-source.ts\` gap is in the \`ForecastDataSource\` subscribe/_resubscribe path, which has no unit-test scaffolding yet — needs a dedicated test PR with mocked HA connection. Out of scope here.
- The \`scroll-ux.ts\` line 344-345 is a defensive try/catch that only fires for genuinely-throwing date inputs (Symbol etc.) — contrived enough to defer.

This PR alone may be enough to flip the SonarCloud \`new_coverage\` Quality Gate ≥ 80 %; verify post-merge.

## Test plan

- [x] \`npm run typecheck\` green
- [x] \`npm run test\` 435/435 (3 new cases)
- [x] \`npm run coverage\` shows openmeteo-source.ts at 100% line
- [x] \`npm run build\` green
- [ ] CI green
- [ ] Post-merge: SonarCloud \`new_coverage\` measure ≥ 80 %, Quality Gate flips to **PASS**

Closes part of #56.