### PR TITLE
Release v1.7.0 — sunshine B2 + main.ts field decls + SonarCloud gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@ All notable changes to this project are documented in this file. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] — 2026-05-07
+
+Quality + sunshine pass. The headline visible win is for users who
+have a lux/illuminance sensor but no dedicated sunshine-duration
+sensor — the past chart's sunshine row now fills in automatically
+from your sensor's history rather than coming up empty when
+Open-Meteo isn't reachable. Everything else is internal: tighter
+typing on the card's main file, a SonarCloud-coverage-gate fix,
+and a small cleanup of the static-analysis backlog.
+
+### Past sunshine: works for users with just an illuminance sensor
+
+If your weather-station has an illuminance sensor (BH1750, TSL2591,
+Ecowitt lux, …) but no dedicated `sensor.sunshine_duration` and no
+internet connection from Home Assistant to Open-Meteo, the past
+block's sunshine row used to come up empty. v1.7 derives sunshine
+duration directly from the lux sensor's history: it walks the
+high-resolution recorder samples and counts time intervals where
+the measured illuminance is at least 60 % of the theoretical clear-
+sky illuminance for that lat/lon and time of day. The threshold is
+tunable via `condition_mapping.sunshine_lux_ratio`.
+
+The result is honest about being a proxy — it's an estimate from
+the sensor, not a WMO-conformant measurement. If you have
+`sensors.sunshine_duration` configured (e.g. via the FL550 / DWD or
+an Open-Meteo REST sensor), that still wins.
+
+### Internal cleanup
+
+- **Field-declaration block on the card class.** The card's main
+  file (`main.ts`) had ~50 instance fields declared implicitly via
+  runtime assignments. They're now explicit class properties with
+  category comments — IDE intellisense lists them, refactor and
+  rename are safer. The full strict-type pass on this file is
+  scheduled for v1.8 (it surfaces the expected ~110 typecheck
+  errors that need a focused refactor).
+- **SonarCloud coverage gate.** The new-code coverage measure
+  was failing the quality gate at 77.9 %. v1.7 adds tests for the
+  silent error-handlers in the Open-Meteo source (corrupted
+  storage, quota exceeded, double-abort polyfills) so the gate
+  flips to passing.
+- **Code-smell cleanup, part one.** Six SonarCloud findings cleared
+  via mechanical fixes — three redundant `Promise.resolve()` calls
+  in async functions, three unnecessary type assertions. The bulk
+  of the 132-finding backlog (cognitive-complexity refactors and
+  Lit-html nested-ternary idioms) stays open for v1.8.
+
+### Issues closed
+
+- #66 — Sunshine past-tier lux derivation (Method B2 from #6)
+- #56 — SonarCloud new-code coverage gate close (partial — see PR
+  #69)
+- #33 — main.ts `@ts-nocheck` field-declaration pass (partial — full
+  strict pass deferred to v1.8 per PR #70)
+- #57 — SonarCloud code-smells cleanup (partial — 6 of 132 cleared
+  per PR #71)
+
 ## [1.6.0] — 2026-05-07
 
 User-facing follow-ups to v1.5 plus dependency hygiene. Two visible

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-station-card",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Lovelace card showing past weather-station measurements with the weather-chart-card layout, plus live current-condition rendering driven by sensor history.",
   "keywords": [
     "home-assistant",


### PR DESCRIPTION
## Release v1.7.0

Quality + sunshine pass. Bumps \`package.json\` to 1.7.0, prepends a [1.7.0] block to CHANGELOG.md.

## Headline visible win

**Past sunshine works for users with just an illuminance sensor.** No \`sensor.sunshine_duration\` configured, no Open-Meteo reachable from your HA instance — the past chart's sunshine row used to come up empty. v1.7's Method B2 derives sunshine duration directly from the lux sensor's high-resolution recorder history: walks the samples, counts intervals where measured / clearsky-lux ≥ 60 % (configurable via \`condition_mapping.sunshine_lux_ratio\`).

## What ships

| # | Slice |
|---|---|
| #66 | Sunshine past-tier B2 lux derivation (full closure) |
| #56 | SonarCloud new-code coverage gate (PR #69) |
| #33 | main.ts field-declaration block, partial (PR #70) — full strict pass = v1.8 |
| #57 | SonarCloud code smells, partial (PR #71) — cognitive-complexity refactors = v1.8 |

## v1.8 carry-over

- **#33** — Full strict pass on main.ts (~110 typecheck errors after v1.7's field declarations land; resolution path documented in the issue's v1.8 scope comment)
- **#57** — Cognitive-complexity refactors of \`chart/plugins.ts:246\` (cog 46) and \`chart/orchestrator.ts:110\` (cog 22), 16× nested-ternary idiom cleanup, ~90 MINOR style backlog
- **#1** HACS Default Repository — release-day activity once v1.x stabilises

## Test plan

- [x] \`npm run build\` green (lint + audit + typecheck + 435 tests + depcheck + rollup)
- [x] CHANGELOG.md leads with [1.7.0] block, dated 2026-05-07
- [x] package.json bumped to 1.7.0
- [x] dist/weather-station-card.js byte-identical to master (release commit is metadata only)
- [ ] CI green
- [ ] **Manual on Pi:** verify a no-sunshine_duration setup with just \`sensors.illuminance\` now shows non-zero sunshine bars on past days
- [ ] After merge, **awaiting user confirmation** before \`git push origin v1.7.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)