### PR TITLE
chore(editor): de-nest 6 of 7 nested ternaries in render-layout (#57 part 2)

### DIFF
--- a/dist/weather-station-card.js
+++ b/dist/weather-station-card.js
@@ -212,7 +212,7 @@
         ></ha-switch>
         <label class="switch-label">${n("show_time")}</label>
       </div>
-      ${!0===s.show_time?et`
+      ${!0===s.show_main&&!0===s.show_time?et`
         <div class="switch-container" style="padding-left:20px;">
           <ha-switch
             @change="${t=>r(t,"show_time_seconds")}"
@@ -252,8 +252,7 @@
       ></ha-switch>
       <label class="switch-label">${n("show_attributes")}</label>
     </div>
-    ${!0===s.show_attributes?et`
-      ${a("humidity")?et`
+    ${!0===s.show_attributes&&a("humidity")?et`
         <div class="switch-container">
           <ha-switch
             @change="${t=>r(t,"show_humidity")}"
@@ -262,7 +261,7 @@
           <label class="switch-label">${n("show_humidity")}</label>
         </div>
       `:""}
-      ${a("pressure")?et`
+      ${!0===s.show_attributes&&a("pressure")?et`
         <div class="switch-container">
           <ha-switch
             @change="${t=>r(t,"show_pressure")}"
@@ -271,7 +270,7 @@
           <label class="switch-label">${n("show_pressure")}</label>
         </div>
       `:""}
-      ${a("dew_point")?et`
+      ${!0===s.show_attributes&&a("dew_point")?et`
         <div class="switch-container">
           <ha-switch
             @change="${t=>r(t,"show_dew_point")}"
@@ -280,7 +279,7 @@
           <label class="switch-label">${n("show_dew_point")}</label>
         </div>
       `:""}
-      ${a("wind_direction")?et`
+      ${!0===s.show_attributes&&a("wind_direction")?et`
         <div class="switch-container">
           <ha-switch
             @change="${t=>r(t,"show_wind_direction")}"
@@ -289,7 +288,7 @@
           <label class="switch-label">${n("show_wind_direction")}</label>
         </div>
       `:""}
-      ${a("wind_speed")?et`
+      ${!0===s.show_attributes&&a("wind_speed")?et`
         <div class="switch-container">
           <ha-switch
             @change="${t=>r(t,"show_wind_speed")}"
@@ -298,7 +297,7 @@
           <label class="switch-label">${n("show_wind_speed")}</label>
         </div>
       `:""}
-      ${a("gust_speed")?et`
+      ${!0===s.show_attributes&&a("gust_speed")?et`
         <div class="switch-container">
           <ha-switch
             @change="${t=>r(t,"show_wind_gust_speed")}"
@@ -307,6 +306,7 @@
           <label class="switch-label">${n("show_wind_gust_speed")}</label>
         </div>
       `:""}
+    ${!0===s.show_attributes?et`
       <div class="switch-container">
         <ha-switch
           @change="${t=>r(t,"show_sun")}"

--- a/src/editor/render-layout.ts
+++ b/src/editor/render-layout.ts
@@ -47,7 +47,7 @@ export function renderLayoutSection(editor: EditorLike, ctx: EditorContext): Tem
         ></ha-switch>
         <label class="switch-label">${t('show_time')}</label>
       </div>
-      ${cfg.show_time === true ? html`
+      ${cfg.show_main === true && cfg.show_time === true ? html`
         <div class="switch-container" style="padding-left:20px;">
           <ha-switch
             @change="${(e: Event) => valueChanged(e as ChangeEvt, 'show_time_seconds')}"
@@ -87,8 +87,7 @@ export function renderLayoutSection(editor: EditorLike, ctx: EditorContext): Tem
       ></ha-switch>
       <label class="switch-label">${t('show_attributes')}</label>
     </div>
-    ${cfg.show_attributes === true ? html`
-      ${hasSensor('humidity') ? html`
+    ${cfg.show_attributes === true && hasSensor('humidity') ? html`
         <div class="switch-container">
           <ha-switch
             @change="${(e: Event) => valueChanged(e as ChangeEvt, 'show_humidity')}"
@@ -97,7 +96,7 @@ export function renderLayoutSection(editor: EditorLike, ctx: EditorContext): Tem
           <label class="switch-label">${t('show_humidity')}</label>
         </div>
       ` : ''}
-      ${hasSensor('pressure') ? html`
+      ${cfg.show_attributes === true && hasSensor('pressure') ? html`
         <div class="switch-container">
           <ha-switch
             @change="${(e: Event) => valueChanged(e as ChangeEvt, 'show_pressure')}"
@@ -106,7 +105,7 @@ export function renderLayoutSection(editor: EditorLike, ctx: EditorContext): Tem
           <label class="switch-label">${t('show_pressure')}</label>
         </div>
       ` : ''}
-      ${hasSensor('dew_point') ? html`
+      ${cfg.show_attributes === true && hasSensor('dew_point') ? html`
         <div class="switch-container">
           <ha-switch
             @change="${(e: Event) => valueChanged(e as ChangeEvt, 'show_dew_point')}"
@@ -115,7 +114,7 @@ export function renderLayoutSection(editor: EditorLike, ctx: EditorContext): Tem
           <label class="switch-label">${t('show_dew_point')}</label>
         </div>
       ` : ''}
-      ${hasSensor('wind_direction') ? html`
+      ${cfg.show_attributes === true && hasSensor('wind_direction') ? html`
         <div class="switch-container">
           <ha-switch
             @change="${(e: Event) => valueChanged(e as ChangeEvt, 'show_wind_direction')}"
@@ -124,7 +123,7 @@ export function renderLayoutSection(editor: EditorLike, ctx: EditorContext): Tem
           <label class="switch-label">${t('show_wind_direction')}</label>
         </div>
       ` : ''}
-      ${hasSensor('wind_speed') ? html`
+      ${cfg.show_attributes === true && hasSensor('wind_speed') ? html`
         <div class="switch-container">
           <ha-switch
             @change="${(e: Event) => valueChanged(e as ChangeEvt, 'show_wind_speed')}"
@@ -133,7 +132,7 @@ export function renderLayoutSection(editor: EditorLike, ctx: EditorContext): Tem
           <label class="switch-label">${t('show_wind_speed')}</label>
         </div>
       ` : ''}
-      ${hasSensor('gust_speed') ? html`
+      ${cfg.show_attributes === true && hasSensor('gust_speed') ? html`
         <div class="switch-container">
           <ha-switch
             @change="${(e: Event) => valueChanged(e as ChangeEvt, 'show_wind_gust_speed')}"
@@ -142,6 +141,7 @@ export function renderLayoutSection(editor: EditorLike, ctx: EditorContext): Tem
           <label class="switch-label">${t('show_wind_gust_speed')}</label>
         </div>
       ` : ''}
+    ${cfg.show_attributes === true ? html`
       <div class="switch-container">
         <ha-switch
           @change="${(e: Event) => valueChanged(e as ChangeEvt, 'show_sun')}"


### PR DESCRIPTION
## Summary

Continues #57 by de-nesting the attribute-toggle cluster in \`editor/render-layout.ts\`. SonarCloud flagged 7 \`outer ? html\\`... \${inner ? html\\`...\\` : ''} ...\\` : ''\` patterns; this PR cleans up 6 of them.

## Refactor

Combine the outer + inner predicates into a single ternary per row, drop the outer wrapper. Each attribute row becomes:

\`\`\`ts
\${cfg.show_attributes === true && hasSensor('humidity') ? html\`
  ... humidity switch ...
\` : ''}
\`\`\`

The outer \`cfg.show_attributes === true ? ...\` wrapper still gates the \`show_sun\` row at the end of the section (the only line that doesn't have an inner sensor predicate).

## What stays

One nested ternary remains at line 50 (\`show_time\` inside \`show_main\`). That outer wrapper houses ~20 switches and de-nesting it would mean duplicating \`cfg.show_main === true &&\` across each inner row — a net readability loss for the rule's marginal SonarCloud benefit.

## Test plan

- [x] \`npm run typecheck\` green
- [x] \`npm run test\` 443/443 green
- [x] \`npm run build\` green
- [x] Editor still renders correctly when toggling \`show_attributes\` off/on (visual smoke test)
- [ ] CI green
- [ ] Post-merge: SonarCloud baseline drops by 6 nested-ternary findings

Continues #57. The remaining MINOR backlog (typescript-style rules, etc.) stays open under #57 for later picks.