### PR TITLE
docs(readme): add SonarCloud quality gate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://hacs.xyz/"><img alt="HACS Custom" src="https://img.shields.io/badge/HACS-Custom-orange.svg" /></a>
   <a href="https://github.com/chriguschneider/weather-station-card/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/chriguschneider/weather-station-card?label=release" /></a>
   <a href="https://github.com/chriguschneider/weather-station-card/actions/workflows/build.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/chriguschneider/weather-station-card/build.yml?label=build" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=chriguschneider_weather-station-card"><img alt="Quality Gate Status" src="https://sonarcloud.io/api/project_badges/measure?project=chriguschneider_weather-station-card&metric=alert_status" /></a>
   <a href="https://github.com/chriguschneider/weather-station-card/releases"><img alt="Total downloads" src="https://img.shields.io/github/downloads/chriguschneider/weather-station-card/total" /></a>
   <a href="https://github.com/chriguschneider/weather-station-card/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/chriguschneider/weather-station-card?style=flat" /></a>
   <a href="https://github.com/chriguschneider/weather-station-card/commits/master"><img alt="Last commit" src="https://img.shields.io/github/last-commit/chriguschneider/weather-station-card" /></a>


### PR DESCRIPTION
## Summary

- Adds a single SonarCloud **Quality Gate** badge to the badge row in `README.md`, linking to the project summary on sonarcloud.io.
- Placed between the **Build** and **Downloads** badges so the CI/quality cluster reads left-to-right.
- One badge instead of separate bugs / coverage / smells — the gate aggregates them and is the single pass/fail readers actually care about. Coverage is already covered indirectly via the 80 % gate inside the `build` workflow.

Quality gate is currently **passed** (verified before opening this PR), so the badge will show green on merge.

## Test plan

- [ ] CI green (`build` + `Analyze (javascript-typescript)`)
- [ ] Badge image loads on the rendered README on the PR's "Files changed" view
- [ ] Click on the badge navigates to the SonarCloud project summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)