### PR TITLE
docs: add ADR template and four accepted records

### DIFF
--- a/docs/adr/0001-dist-committed-for-hacs.md
+++ b/docs/adr/0001-dist-committed-for-hacs.md
@@ -1,0 +1,58 @@
+# 0001: Commit `dist/weather-station-card.js` alongside source
+
+**Status:** Accepted
+
+**Date:** 2026-05-08
+
+## Context
+
+This card is distributed via [HACS](https://hacs.xyz/), the Home Assistant Community Store. HACS installs custom cards by downloading a single `.js` file referenced as a release asset on a tagged GitHub Release. There is no npm registry step, no CDN bundler, no per-user build.
+
+The card is also testable on a live HA instance during development by serving the bundle directly from a `raw.githubusercontent.com` URL pointing at a branch — the user pastes the URL into Lovelace's resources list and reloads. That path also requires `dist/weather-station-card.js` to be present at the referenced commit.
+
+The reflexive answer for a JavaScript project is "gitignore `dist/` and let CI build artifacts from source." That works for npm packages and web apps deployed via CI. It does **not** work for HACS, because HACS does not run a build — it downloads the file you point it at.
+
+Alternatives considered:
+
+- **Gitignore `dist/`, build only on tag-push, attach asset to Release.** Breaks branch-based dev installs (no `dist/` on the branch → 404 from `raw.githubusercontent.com`). Also makes "verify the bundle matches the source" harder to enforce during PR review.
+- **Use a separate `release` branch that only contains the built bundle.** Adds a release-time step that's easy to forget; doubles the number of branches that need to track.
+- **Commit `dist/` alongside source and verify in CI.** What we do.
+
+## Decision
+
+`dist/weather-station-card.js` is committed to the repository alongside the TypeScript source. The release flow rebuilds and re-commits it as part of the release commit (see `CONTRIBUTING.md`).
+
+CI enforces sync: `.github/workflows/build.yml` runs `npm run build` and then aborts the job if `git diff --quiet -- dist/weather-station-card.js` reports a difference, with an explicit error pointing at the fix:
+
+```
+::error::dist/weather-station-card.js is out of sync with source.
+Run 'npm run build' and commit the result.
+```
+
+`.gitignore` excludes only `dist/*.gz` (build-time gzip artefacts that aren't part of the shipped card) — the `.js` itself is tracked.
+
+## Consequences
+
+**Pros**
+
+- HACS installs work the moment a tag is pushed — the bundle is already in the tree.
+- Branch-based dev installs (`raw.githubusercontent.com/.../<branch>/dist/...`) work without a CI round-trip.
+- PR review can see the bundle diff alongside the source diff, catching accidental dist/source drift.
+- The CI sync gate guarantees that what's released matches what was reviewed.
+
+**Cons**
+
+- Larger PR diffs — the minified bundle changes on almost every PR.
+- Every release commit has to include the rebuilt `dist/`, which is a manual step easy to forget. CI catches it but the round-trip costs ~3 minutes.
+- Merge conflicts in `dist/weather-station-card.js` are unreadable; the resolution is always "rebuild after rebase."
+
+**Tradeoffs**
+
+- The "gitignore dist/, build in CI" pattern is the modern default for npm libraries and web apps. We forgo it because HACS cannot run a build and we don't want a separate distribution channel.
+- A `release` branch holding only the bundle was rejected because it doubles the number of refs to maintain and the dev-install workflow would need to differentiate between `master` (source) and `release` (bundle).
+
+## Related
+
+- [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) — release flow
+- [`../../.github/workflows/build.yml`](../../.github/workflows/build.yml) — `Verify committed bundle matches source` step
+- [HACS docs — Custom card requirements](https://hacs.xyz/docs/publish/start)

--- a/docs/adr/0002-sunshine-duration-tier-policy.md
+++ b/docs/adr/0002-sunshine-duration-tier-policy.md
@@ -1,0 +1,70 @@
+# 0002: Sunshine duration — tiered data-source policy
+
+**Status:** Accepted
+
+**Date:** 2026-05-08
+
+## Context
+
+The sunshine-duration row (configurable via `forecast.show_sunshine`) shows two values: hours of sunshine *today* and a forecast for *tomorrow* (or the next N days). Sunshine duration is not a primary HA forecast attribute and is not measured by typical home weather stations. The card therefore has to derive it.
+
+Several derivation paths are possible, each with different fidelity, cost, and configuration burden:
+
+- **A — measured.** A dedicated sunshine-duration sensor (`sensor.sunshine_today`) feeds the past tier directly. Highest fidelity. Requires the user to wire up an Open-Meteo REST template (or an equivalent) themselves.
+- **B — illuminance-derived.** An illuminance/lux sensor exists in nearly every home weather station. We can integrate it against a clear-sky lux model (`clearSkyLuxFactory`) and count seconds where the ratio exceeds a threshold (default 0.6).
+  - **B1** uses the live (current-state) lux value only — fine for "is it sunny right now" but poor for "how many hours today."
+  - **B2** walks the recorder/history samples for the lux sensor and integrates over the day.
+- **F — open-meteo direct.** A REST call to Open-Meteo's `meteoswiss_icon_seamless` (or another) model exposes daily and hourly sunshine forecasts.
+  - **F2** is the daily forecast tier.
+  - **F3** is the hourly cloud-coverage fallback when no dedicated sunshine forecast is available — applies the Kasten formula `sunshine_h ≈ day_length × (1 − (cc/100)^p)` with `p ≈ 3`.
+- **C — clear-sky geometric.** Compute astronomical day length and discount it by current cloud cover. Trivially available where Open-Meteo is already wired up; coarse.
+
+Each tier has a different "what data does the user already have?" prerequisite. Forcing all users into Method A would gatekeep the feature on a multi-step REST setup; forcing all into Method F would make Open-Meteo a hard dependency for a card that's otherwise self-contained.
+
+## Decision
+
+Two slots: **past tier** (today / yesterday) and **forecast tier** (tomorrow / next N days). Each slot picks the highest-fidelity available source at runtime, falling back through the tiers below it.
+
+**Past tier preference order:**
+
+1. Method A — `condition_mapping.sunshine_today` sensor if configured and numeric.
+2. Method B2 — `condition_mapping.illuminance` sensor history walked via `sunshineFromLuxHistory(samples, lat, lon, threshold, maxIntervalMs)`. Threshold tunable via `condition_mapping.sunshine_lux_ratio` (default 0.6); samples fetched via `hass.callWS({ type: 'history/history_during_period', ... })`.
+3. Fallback to forecast-tier value for "today" if neither is configured.
+
+**Forecast tier preference order:**
+
+1. Method F2 — `condition_mapping.sunshine_forecast` REST sensor with daily / hourly arrays.
+2. Method F3 — Kasten-formula approximation from `cloud_coverage` forecast attributes when no dedicated sunshine forecast is configured.
+
+The decisions encoded in `src/sunshine-source.ts` are referenced by code in the file header (A1 = Variant A: Methods F + C only [historical]; A2 = two slots; A3 = F2 forecast tier; A6 naming). The decision codes themselves were defined in GitHub issue #6 — this ADR is the durable in-repo record of the resulting architecture.
+
+Configuration knobs live under `condition_mapping.*` so the user can opt in / out per sensor without changing the card's data-flow shape.
+
+## Consequences
+
+**Pros**
+
+- Users with a fully-wired Open-Meteo REST template + dedicated sunshine sensor get measured fidelity automatically.
+- Users with only an illuminance sensor still get a reasonable past-tier value (Method B2) without configuring a REST integration.
+- Users with neither still get a forecast-tier estimate (Method F3 from `cloud_coverage`) as long as their forecast entity exposes cloud cover.
+- The fallback chain is monotone: turning off a higher tier always degrades to the next-best, never to "no value."
+
+**Cons**
+
+- Four tiers (A, B2, F2, F3) means four code paths to test and four classifier branches in the card. The complexity is real — `sunshine-source.ts` and `openmeteo-source.ts` together are ~600 LOC.
+- Method B2 depends on `recorder` retention and a high-resolution lux sensor; if either is degraded (e.g. lux sensor reports every 5 minutes), the integral is noisy.
+- Method F3's Kasten exponent `p ≈ 3` is empirical; Bern-area calibration may not generalize. (Tracked in issue #6 follow-ups.)
+
+**Tradeoffs**
+
+- A single-tier "Method A only" design was rejected because the REST setup gatekeeps the row behind ~20 lines of YAML.
+- A "Method F only, always" design was rejected because Open-Meteo isn't always available (rural users, EU privacy preferences) and because measured data, when present, is strictly better than forecast.
+- B1 (live-state-only lux) was rejected because it can't answer "how many hours today" — it only answers "is it sunny right now."
+
+## Related
+
+- [`../../src/sunshine-source.ts`](../../src/sunshine-source.ts) — past-tier helpers
+- [`../../src/openmeteo-source.ts`](../../src/openmeteo-source.ts) — F-tier fetcher
+- [`../../src/condition-classifier.ts`](../../src/condition-classifier.ts) — `clearSkyLuxFactory`
+- [Issue #6](https://github.com/chriguschneider/weather-station-card/issues/6) — original A1/A2/A3/A6 decisions
+- [Issue #66](https://github.com/chriguschneider/weather-station-card/issues/66) — Method B2 lux-derivation

--- a/docs/adr/0003-e2e-baselines-pinned-to-gha.md
+++ b/docs/adr/0003-e2e-baselines-pinned-to-gha.md
@@ -1,0 +1,61 @@
+# 0003: E2E visual-regression baselines pinned to the GHA Ubuntu runner
+
+**Status:** Accepted
+
+**Date:** 2026-05-08
+
+## Context
+
+The card has a Playwright visual-regression suite under `tests-e2e/` that compares rendered card output against PNG snapshots committed under `tests-e2e/snapshots/render-modes.spec.ts/`. The comparison runs in CI against `pixelDiff` thresholds in `playwright.config.ts`.
+
+Visual-regression diffs are sensitive to **subpixel rendering**, which differs between platforms:
+
+- The GHA `ubuntu-latest` runner uses Mesa's software rasterizer in a specific kernel/font configuration.
+- WSL2 (a common local dev environment for this repo) virtualizes the GPU and renders text with subtly different font hinting.
+- macOS and native Linux render differently again.
+
+A baseline generated locally on WSL and compared against a screenshot generated on GHA shows ~1–4 % diffs on text-heavy regions, even when the actual UI is byte-for-byte identical. That diff is too large for a useful tolerance: anything looser than ~1 % is too coarse to catch real regressions like a 1-px text shift or a colour change in the chart legend.
+
+Two paths out:
+
+- **Loose tolerance.** Set `pixelDiff` to ~2 % so WSL-generated baselines pass on GHA. Misses real regressions.
+- **Tight tolerance + canonical environment.** Set tolerance to 0.2 % and require all baselines to come from the same environment as the assertion run.
+
+## Decision
+
+E2E visual baselines are **regenerated exclusively on the GHA `ubuntu-latest` runner**. The Playwright tolerance sits at 0.2 %.
+
+The `update-baselines.yml` workflow is the canonical baseline-generation path. It is manually triggered (`gh workflow run update-baselines.yml --ref <branch>`), runs Playwright with `--update-snapshots` after deleting the existing PNGs, and pushes a `chore: update e2e baselines from CI` commit back to the branch.
+
+WSL is supported as a "does the chart still render at all" smoke test during local iteration but **its baseline output must never be committed**. WSL baselines drifted from GHA cause PR review to fail with a noisy diff that the contributor cannot reproduce locally.
+
+The workflow:
+
+1. Hard-deletes existing PNG baselines so Playwright writes every file fresh. (Without the delete, `--update-snapshots` skips files that already pass under the loose update-pass logic.)
+2. `git pull --rebase` before push so master can advance during the ~2-minute run without a race on push.
+
+## Consequences
+
+**Pros**
+
+- 0.2 % tolerance is tight enough to flag 1-px text shifts and minor colour drift — the kind of regressions that matter.
+- The baseline-generation environment is part of the test contract, not a per-contributor concern. No "works on my machine" debugging.
+- Baselines are reproducible by anyone with `gh workflow run` access — no privileged dev machine required.
+
+**Cons**
+
+- A baseline regen takes ~2 minutes (workflow dispatch round-trip) versus seconds for a local update. Contributors must remember to dispatch the workflow rather than run `--update-snapshots` locally.
+- Committing WSL baselines is a foot-gun that will silently bite: locally the suite passes; on PR it fails with a diff the contributor cannot reproduce. The mitigation is documentation (this ADR + workflow header) rather than a hard guard.
+- Pinning to GHA `ubuntu-latest` means a future runner upgrade (Ubuntu 24.04 → 26.04, font-package update) shifts all baselines at once. Recovery is "regenerate on the new image and review the wholesale diff."
+
+**Tradeoffs**
+
+- A loose tolerance (~2 %) was rejected because it permits real regressions to slip through.
+- A platform-matrix baseline set (one per OS) was rejected because the multiplication of snapshot files makes review unmanageable and adds nothing — the production target is a single browser environment per render.
+- Containerizing the baseline generation locally (e.g. via Docker) was considered but adds toolchain complexity for the rare case of regen; the dispatched workflow is simpler.
+
+## Related
+
+- [`../../.github/workflows/update-baselines.yml`](../../.github/workflows/update-baselines.yml) — canonical regen path
+- [`../../tests-e2e/snapshots/`](../../tests-e2e/) — committed baselines
+- [`../../playwright.config.ts`](../../playwright.config.ts) — tolerance config

--- a/docs/adr/0004-typescript-strict-with-boundary-relaxations.md
+++ b/docs/adr/0004-typescript-strict-with-boundary-relaxations.md
@@ -1,0 +1,65 @@
+# 0004: TypeScript — strict for leaf modules, `any` allowed at the HA boundary
+
+**Status:** Accepted
+
+**Date:** 2026-05-08
+
+## Context
+
+The card was migrated from JavaScript to TypeScript in v1.2 and runs under `tsc --strict` since v1.8 (#33). "Strict everywhere" is the obvious goal, but the integration boundary against Home Assistant resists it cheaply.
+
+`src/main.ts` is the LitElement integration boundary — ~1500 LOC of `set hass` / `setConfig` / render glue, plus ~30 instance fields that hold HA-shaped state (forecasts, weather, current sensor readings, scroll-ux teardowns, animation controllers, …). The HA frontend exposes a `HomeAssistant` type, but importing it pulls in a chain of frontend dependencies the card otherwise doesn't use:
+
+- Lovelace card-config types
+- HA's localization machinery
+- Theming and connection-state types
+
+Adopting `HomeAssistant` directly would add ~6 transitive `@types/*` imports for a ~1500-LOC class. Mocking those types where they're missing in the public API would add a parallel maintenance burden. Threading `HassLike` through every render path would touch ~50 fields and most call sites.
+
+Two paths:
+
+- **Strict everywhere.** Adopt the full HA frontend type imports. ~6 new deps; non-trivial test-mock surface; no runtime improvement.
+- **Strict on leaves, relaxed at the boundary.** Define a minimal `HassLike` interface in `data-source.ts`. Leaf modules (data-source, chart/*, sunshine-source, openmeteo-source, scroll-ux, action-handler, editor/*) type-check cleanly; main.ts uses `HassMain extends HassLike` plus `any`-typed fields for HA-shaped slots whose frontend types aren't documented.
+
+## Decision
+
+**Leaf modules** — everything in `src/` *except* `main.ts` — are fully strict-typed. They export typed APIs; downstream contributors get types when they import from this card.
+
+**`src/main.ts`** is the relaxed integration boundary:
+
+- Class extends `HassLike` (defined in `data-source.ts`) for the `hass` field.
+- `_dataSource: MeasuredDataSource | null` and `_forecastSource: ForecastDataSource | null` are typed.
+- The synthesised `weather` / `temperature` / editor-callback-payload fields use `any`, with `eslint-disable` lines limited to those exact slots.
+- No `@ts-nocheck` on the file as a whole — that was removed in v1.8 (#33).
+
+ESLint encodes the relaxations explicitly in `eslint.config.mjs` (the rules disabled there — `no-explicit-any`, `no-unsafe-*`, `restrict-template-expressions`, `restrict-plus-operands`, `no-misused-promises`, `unbound-method` — exist because typed-rule false-positives on `any`-flavoured HA objects would generate noise that doesn't surface real bugs).
+
+`@ts-nocheck`, `@ts-ignore`, and `@ts-expect-error` require a justification of at least 10 characters (`'allow-with-description'`).
+
+## Consequences
+
+**Pros**
+
+- The card has zero `@types/home-assistant-frontend` (or equivalent) dependency, which would otherwise pull a long chain of UI-only types.
+- Leaf-module exports are strictly typed, so anyone importing helpers from this card gets full type information.
+- The boundary is named (`HassLike` / `HassMain`) and enforced — adding a new HA-shaped field forces a deliberate placement decision.
+- ESLint relaxations are explicit and rule-by-rule, not global. A future tightening can promote one rule at a time.
+
+**Cons**
+
+- `main.ts` keeps ~30 `any`-typed fields; refactors to it cannot rely on type-checking for HA-shaped slots.
+- The "strict everywhere except main.ts" rule is a convention, not a structural guarantee. A new contributor could land an `any` in a leaf module and would need to be caught in review.
+- Two rule sets to remember: leaf modules vs. integration boundary.
+
+**Tradeoffs**
+
+- Adopting `@types/home-assistant-frontend` was rejected as ~6 transitive deps for ~1500 LOC of glue — the value-per-dep ratio is low and the maintenance cost is real.
+- Tightening main.ts incrementally is tracked as future follow-up rather than blocking v1.8. Each `any` removed is its own decision about whether the corresponding HA frontend type is worth importing.
+- A `@ts-nocheck` blanket on main.ts (the v1.7-and-earlier state) was rejected because it disables type-checking for the strictly-typed slots too, including `_dataSource` and `_forecastSource`.
+
+## Related
+
+- [`../../src/main.ts`](../../src/main.ts) — file header documents the boundary
+- [`../../src/data-source.ts`](../../src/data-source.ts) — `HassLike` definition
+- [`../../eslint.config.mjs`](../../eslint.config.mjs) — rule relaxations
+- [Issue #33](https://github.com/chriguschneider/weather-station-card/issues/33) — strict pass on main.ts

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,42 @@
+# Architecture Decision Records
+
+This directory captures the **why** behind non-obvious architectural choices in
+this card. Code shows *what* the implementation does; ADRs explain *why* a
+particular path was chosen and what alternatives were rejected.
+
+## When to write one
+
+Write an ADR when a decision is:
+
+- **Hard to reverse** — package upgrades, bundler swaps, public-API shape, data-source contracts.
+- **Surprising without context** — choices a future reader (or future Claude) would otherwise undo by accident.
+- **Cross-cutting** — touches multiple modules and can't be explained inside a single file's header comment.
+
+Skip the ADR for routine bug fixes, refactors that don't change a contract, or
+decisions whose rationale already lives in the commit message.
+
+## How to add one
+
+1. Copy [`template.md`](./template.md) to a new file.
+2. Number it with the next free four-digit prefix and a `kebab-case` slug:
+   `0001-some-decision.md`, `0002-another-one.md`, …
+3. Fill in **Status**, **Date** (YYYY-MM-DD), **Context**, **Decision**, **Consequences**, **Related**.
+4. Land it via the normal PR flow — ADRs are versioned with the code they describe.
+
+## Status lifecycle
+
+- **Proposed** — under discussion; not yet acted on.
+- **Accepted** — in force; the codebase reflects this decision.
+- **Deprecated** — no longer applies, but kept for historical context.
+- **Superseded by NNNN** — replaced by a later ADR; link forward.
+
+ADRs are append-only — once accepted, don't rewrite history. If a decision
+changes, write a new ADR that supersedes the old one and update the old one's
+status line.
+
+## Index
+
+- [0001 — Commit `dist/weather-station-card.js` alongside source](./0001-dist-committed-for-hacs.md) (Accepted)
+- [0002 — Sunshine duration: tiered data-source policy](./0002-sunshine-duration-tier-policy.md) (Accepted)
+- [0003 — E2E visual-regression baselines pinned to the GHA Ubuntu runner](./0003-e2e-baselines-pinned-to-gha.md) (Accepted)
+- [0004 — TypeScript: strict for leaf modules, `any` allowed at the HA boundary](./0004-typescript-strict-with-boundary-relaxations.md) (Accepted)

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,31 @@
+# NNNN: Title
+
+**Status:** Proposed | Accepted | Deprecated | Superseded by NNNN
+
+**Date:** YYYY-MM-DD
+
+## Context
+
+What is the issue, and what factors are influencing the decision? Sketch the alternatives that were on the table.
+
+## Decision
+
+What did we decide to do? Be specific — name files, modules, patterns, versions.
+
+## Consequences
+
+**Pros**
+
+- What benefits does this bring?
+
+**Cons**
+
+- What drawbacks or costs come with it?
+
+**Tradeoffs**
+
+- What alternatives were considered, and why were they rejected?
+
+## Related
+
+- Links to related ADRs, issues, or external references.


### PR DESCRIPTION
## Summary

- Establishes `docs/adr/` as the home for Architecture Decision Records, with a template that mirrors the structure used in chrigu's `homeassistant` repo.
- Lands four ADRs capturing non-obvious architectural choices that weren't durably recorded elsewhere (`dist/` committed for HACS, sunshine-duration tier policy, GHA-pinned E2E baselines, TS strict + boundary relaxations).
- Includes `docs/adr/README.md` explaining when to write an ADR, the lifecycle, and indexing the four.

## Why

Several of the load-bearing decisions in this repo only existed in scattered places: the gitignored `CLAUDE.md`, an external GitHub issue thread (#6), or a single file's header comment. The ADRs consolidate the rationale in a discoverable, version-controlled location so future contributors (human or AI) can find the *why* without spelunking.

## Test plan

- [ ] Read each ADR for accuracy against the actual code state at this commit.
- [ ] Verify the index in `docs/adr/README.md` links resolve.
- [ ] CI (`build` + `Analyze`) passes — this is a docs-only change so no behavioural risk, but the ESLint lint job runs on `tests-e2e` and `src` only and shouldn't be affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)