### PR TITLE
docs(readme): drop visual-editor from hero row, surface inside Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,10 @@ forecast — driven by sensor data, not a `weather.*` entity.
 <tr>
 <th>Main panel + chart</th>
 <th>Standalone chart</th>
-<th>Visual editor</th>
 </tr>
 <tr>
 <td><img alt="Daily combination with sunshine" src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/tests-e2e/snapshots/render-modes.spec.ts/daily-combination-sunshine.png"></td>
 <td><img alt="Daily station-only chart with sunshine" src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/tests-e2e/snapshots/render-modes.spec.ts/daily-station-sunshine.png"></td>
-<td><img alt="Visual editor" src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/tests-e2e/snapshots/editor-visual.spec.ts/editor.png"></td>
 </tr>
 </table>
 
@@ -247,6 +245,10 @@ The visual editor groups options into six sections — Setup, Sensors,
 Layout, Style & Colours, Units, Advanced. Each key is documented in
 **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)** with type, default,
 and effect.
+
+<p align="center">
+  <img alt="Visual editor" src="https://raw.githubusercontent.com/chriguschneider/weather-station-card/master/tests-e2e/snapshots/editor-visual.spec.ts/editor.png" width="720" />
+</p>
 
 For the most common adjustments:
 


### PR DESCRIPTION
## Summary

Implements option (c) from #82 — removes the visual-editor thumbnail from the README hero row and relocates it into the **Configuration** section where it illustrates the surrounding text instead of competing with the chart screenshots.

- Hero row becomes a clean 2-up of the actual value prop (Combination + Station chart).
- `editor.png` is shown half-page-wide (`width="720"`) inside the Configuration section, right after the paragraph that already mentions the visual editor's six groups.

## Why

The editor screenshot is essentially a vertical list of form labels. Next to two dense chart screenshots in the hero, it carries no visual weight and dilutes the first impression. A HACS visitor's first scroll should sell what the card *does* (the chart), not how it's configured.

Discussion and option trade-offs in #82.

## What does *not* change

- `tests-e2e/snapshots/editor-visual.spec.ts/editor.png` is untouched — same baseline, same auto-update flow via `update-baselines.yml`.
- No e2e or visual-regression test changes.
- No Configuration-doc reorganisation; the editor is still discoverable on first scroll past the example config.

## Test plan

- [ ] CI green (`build` + `Analyze (javascript-typescript)`)
- [ ] Hero row renders as a 2-up on the GitHub README preview
- [ ] Editor screenshot in the Configuration section is centered and ≤720px wide
- [ ] Issue #82 auto-closes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)