### PR TITLE
ci: cancel superseded workflow runs on the same ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,14 @@ on:
     branches: [master]
   workflow_dispatch:
 
+# Cancel superseded runs on the same ref so iterative pushes (especially
+# from AI-assisted branches that push 3-5 times before CI green) don't
+# stack up. Tag pushes are excluded — they upload release assets, so
+# every tag run must complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,12 @@ on:
     # Every Monday 06:00 UTC.
     - cron: '0 6 * * 1'
 
+# Cancel superseded runs on the same ref. The weekly schedule still runs
+# regardless because each scheduled run gets its own ref-derived group key.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (javascript-typescript)

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -16,6 +16,10 @@ on:
     branches: [master]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds `concurrency:` blocks to `build.yml`, `codeql.yml`, and `sonarcloud.yml` so iterative pushes on the same ref cancel earlier in-flight runs instead of stacking. `update-baselines.yml` is intentionally excluded (manual dispatch — racing pushes are the whole point).

`build.yml`'s `cancel-in-progress` is conditional on the ref not being a tag, so release tag pushes still run to completion (they upload the GitHub Release asset that HACS picks up).

This is the first concrete deliverable from the research in #127 — the cheap, independent CI-cost win identified under question 8.

## Test plan

- [ ] CI runs at all on this PR (proves the YAML is valid)
- [ ] A second push to this branch cancels the first run (visible in Actions tab)
- [ ] Tag-push behaviour unchanged: spot-check the next release that the build runs end-to-end (release-asset upload step reached)

## Issues

Refs #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)