### PR TITLE
docs: update stale colour-default references after #121 / #134

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -70,14 +70,17 @@ panel's attribute row will now read `humidity`, `pressure`,
 when present. **No YAML change is required**; this is informational so
 you know why attributes might appear that previously didn't surface.
 
-### Theme-aware default chart colours
+### Theme-aware default chart colours (introduced v1.9.0, reverted v1.10.x)
 
-Chart line / bar colour defaults follow the user's HA theme via CSS
-custom properties (e.g.
-`var(--state-sensor-temperature-color, rgba(255, 152, 0, 1.0))`).
-Light/dark theme switches now shift the chart hues automatically.
-**No YAML change required**; user-set RGBA / hex / hsl strings still
-override (pass-through).
+v1.9.0 wired chart line / bar colour defaults to HA theme tokens
+(`var(--token, rgba-fallback)`). The follow-up audit in #121 found
+that some of those tokens didn't mean what their names suggested
+(`--warning-color` is HA's alert orange, not "warm yellow") and others
+didn't actually exist in HA at all. Defaults are now back to literal
+RGBA strings that don't drift per theme. **No YAML change required in
+either direction**; user-set RGBA / hex / hsl strings still
+pass-through, and you can opt back into theme-driven colouring by
+passing your own `var(--token, fallback)` string in YAML.
 
 ### Editor sizing / colours / font-sizes are YAML-only
 

--- a/docs/SENSORS.md
+++ b/docs/SENSORS.md
@@ -69,7 +69,7 @@ The card uses your Home Assistant location (`hass.config.latitude`
 / `longitude`) to query Open-Meteo, fetches once on first render, and
 re-fetches at most once an hour. The response covers the past N days
 plus the next N forecast days in a single call. The bar colour is
-`forecast.sunshine_color` (default Material amber).
+`forecast.sunshine_color` (default `#FFD700` yellow).
 
 **Privacy note**: enabling sunshine sends your latitude / longitude to
 `api.open-meteo.com` from each browser that renders the dashboard. The


### PR DESCRIPTION
## Summary

Two doc references still described the v1.9.0 theme-aware colour defaults that were reverted in #133 / #134:

- `MIGRATION.md` — the v1.9.0 "Theme-aware default chart colours" entry rewritten to note that v1.10.x reverted to literal RGBA after the #121 audit found semantic mismatches and non-existent tokens. No YAML change needed in either direction; users keep the opt-in to theme-driven colouring via their own `var(...)` strings.
- `docs/SENSORS.md` — "default Material amber" referred to the old `--warning-color` resolution; new default is plain `#FFD700` yellow.

## What's intentionally NOT changed

Historic CHANGELOG release blocks for `[1.9.0]` and earlier still describe the colour defaults as theme-aware — that was true at the time of those releases, and Keep-a-Changelog is append-only. The `[Unreleased]` block (updated in #133 / #134) carries the current truth.

## Test plan

- [ ] CI green (lint + audit + typecheck + tests + bundle — all pure-docs change should be uneventful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)