### PR TITLE
docs: split CLAUDE.md, add AGENTS.md + QUALITY-GATES.md (#131)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ don't apply.
 <!-- Checklist of what to verify. Examples:
 - [ ] `npm run build` passes locally
 - [ ] New unit test for X covers the regression
-- [ ] Smoke-tested on Pi (Pi setup is in CLAUDE.md)
+- [ ] Smoke-tested locally (see [LOCAL-TESTING.md](../LOCAL-TESTING.md) for the Docker recipe; maintainers may use a live HA instance instead)
 -->
 
 - [ ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,129 @@
+# AGENTS.md
+
+Conventions for AI-assisted contributions to this repo. Read this if
+you're a contributor using Claude Code, Cursor, Codex, Aider, or any
+other AI assistant on a fork or a branch — or if you're an AI assistant
+yourself reading the repo for the first time.
+
+Everything in [`CONTRIBUTING.md`](CONTRIBUTING.md) still applies. This
+file only covers the conventions that genuinely differ for AI-assisted
+work.
+
+## Commit attribution
+
+Commits made with AI assistance should carry a `Co-Authored-By:` trailer
+that names the tool and model honestly:
+
+```
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+Co-Authored-By: Cursor <noreply@cursor.sh>
+Co-Authored-By: Codex <noreply@openai.com>
+```
+
+The exact string isn't load-bearing — what matters is that git history
+reflects the tool that did the typing. The maintainer's local
+trailer is documented in their per-machine `CLAUDE.md` and is not the
+canonical form for contributors.
+
+## Comment discipline
+
+Inline comments earn their place by explaining the *why* — a hidden
+constraint, a subtle invariant, a workaround. Don't restate code.
+
+```ts
+// Bad — restates what the next line obviously does.
+// Increment the counter
+counter += 1;
+
+// Good — encodes a non-obvious reason.
+// HA emits an extra forecast tick at midnight UTC; drop it so the
+// chart doesn't grow a phantom column.
+counter += 1;
+```
+
+Multi-paragraph docstrings on small functions and "why we removed X"
+breadcrumbs both add noise. The PR description is the place for
+context that doesn't survive the diff.
+
+## Architectural decisions
+
+If your change introduces a new architectural pattern, breaks a
+module boundary, swaps a build/quality gate, or deviates from an
+existing ADR, it likely needs an ADR of its own. Triggers and the
+template live in [`docs/adr/README.md`](docs/adr/README.md). Land the
+ADR alongside the code, not after.
+
+Claude Code users in this clone get an automatic prompt for ADR
+candidates via the `documentation` skill (see below). Other tools
+won't fire that prompt — read `docs/adr/README.md` directly.
+
+## Repo-local skills
+
+Two Claude Code skills are checked into `.claude/skills/`:
+
+- **`commit-guardian`** — runs before any `git commit` and checks the
+  staged diff against accepted ADRs and the conventions in
+  `CONTRIBUTING.md` / `ARCHITECTURE.md` / `docs/STYLE-GUIDE.md`.
+  Findings are reported as a numbered list; the user decides whether
+  to proceed.
+- **`documentation`** — proactively suggests ADRs when an
+  architectural change happens, and flags code changes that contradict
+  an existing decision.
+
+These auto-load for Claude Code users in this clone. Other AI tools
+(Cursor, Codex, Aider) don't load them — read the `SKILL.md` files
+directly to pick up the conventions they enforce.
+
+## Parallel work
+
+When multiple agents (or one agent + a human) might be in the repo at
+the same time, two cheap habits avoid collisions:
+
+- **Branch naming**: `<tool-or-initials>/<issue>-<slug>`, e.g.
+  `claude/127-parallel-workflow-research`, `cursor/45-fix-scroll`. Makes
+  authorship visible in `git branch --remotes` without a team agreement.
+- **Issue claiming**: `gh issue edit <N> --add-assignee @me` before
+  starting work on an open issue, so other contributors see it's
+  taken.
+
+For local working trees, `git worktree add ../wsc-<issue> <branch>`
+gives each agent its own `dist/` and `node_modules` and avoids
+clobbering across parallel branches. Optional — single-agent flows
+don't need it.
+
+## Draft PRs
+
+CI runs the full pipeline (lint + audit + typecheck + tests +
+coverage + depcheck + bundle + e2e + visual regression) on every
+push, ~6 minutes per run. If you're iterating with several pushes
+per branch, **open the PR as a draft** until you expect CI to pass,
+then mark ready. The maintainer-facing notification noise (and the
+GHA cost) is otherwise multiplied by your iteration count.
+
+## Resolving `dist/` conflicts on rebase
+
+When master advances during your branch's life, you may hit a merge
+conflict in `dist/weather-station-card.js`. **Don't hand-merge the
+minified bundle.** Take either side, then:
+
+```bash
+npm run build
+git add dist/weather-station-card.js
+git rebase --continue
+```
+
+The `verify dist matches HEAD` step in CI would catch a hand-merged
+bundle anyway, so re-running the bundler is the only path that holds.
+This is a documented consequence of [ADR-0001 (dist committed for
+HACS)](docs/adr/0001-dist-committed-for-hacs.md), kept out of an
+ADR amendment because the underlying decision still stands.
+
+## Testing UI changes
+
+For changes that need eyeballing against a real Home Assistant
+instance, use the Docker recipe in [`LOCAL-TESTING.md`](LOCAL-TESTING.md).
+Visual baselines under `tests-e2e/snapshots/` are regenerated only by
+the [`update-baselines.yml`](.github/workflows/update-baselines.yml)
+workflow on the GHA runner — never commit baselines from a local
+Playwright run, the rendering tolerance won't match (see
+[ADR-0003](docs/adr/0003-e2e-baselines-pinned-to-gha.md)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,21 @@ SonarCloud and Dependabot run on PRs too but are advisory; CodeQL's
 Linear history is enforced (no merge commits) — the maintainer uses
 `gh pr merge --rebase` to land PRs.
 
+[`docs/QUALITY-GATES.md`](docs/QUALITY-GATES.md) is the full reference
+for what each gate enforces, the lint-warnings backlog policy, the
+SonarCloud exclusions, and the Dependabot review conventions (no
+auto-merge, watch for wrapper-deprecations on Actions, manual
+changelog read on major bumps).
+
+## AI-assisted contributions
+
+PRs from contributors using Claude Code, Cursor, Codex, or other AI
+assistants are welcome — see [`AGENTS.md`](AGENTS.md) for the
+conventions specific to AI-assisted work (commit attribution, comment
+discipline, parallel-work coordination, draft-PR convention,
+`dist/`-rebase recipe). Everything in this file applies to those PRs
+too.
+
 ## Tests
 
 Pure-function unit tests live under `tests/` and run via Vitest. See

--- a/TESTING.md
+++ b/TESTING.md
@@ -150,17 +150,40 @@ Animations are disabled per-test by setting
 500 ms easeOutQuart on the temperature line doesn't make the
 screenshot timing race-prone.
 
+<a id="updating-visual-baselines"></a>
 ### Updating baselines after a deliberate UI change
 
+Visual baselines are pinned to the GitHub Actions `ubuntu-latest`
+runner (see [ADR-0003](docs/adr/0003-e2e-baselines-pinned-to-gha.md)).
+The comparison environment matches the assertion environment exactly,
+which is what lets the Playwright tolerance sit at 0.2 % — tight
+enough to catch subtle regressions like 1-px text shifts. The flip
+side is that **locally-generated PNGs diff 1–4 % against the GHA
+images** and must not be committed.
+
+The supported regen path is the
+[`update-baselines.yml`](.github/workflows/update-baselines.yml)
+workflow:
+
 ```bash
-npm run test:e2e:update
-git add tests-e2e/snapshots
-git commit -m "Refresh E2E baselines after <change>"
+gh workflow run update-baselines.yml --ref <your-feature-branch>
+gh run list --workflow update-baselines.yml \
+  --event workflow_dispatch --limit 1
+gh run watch <run-id> --exit-status
 ```
 
-Always include the *why* in the commit — a baseline change is a
-visual contract change, and reviewers can't tell from the .png alone
-whether the diff is intended.
+The bot pushes a `chore: update e2e baselines from CI` commit on top
+of the dispatched branch with the regenerated PNGs. Pull, review the
+diff, merge through the normal PR flow.
+
+> **Branch protection note.** The bot can push to feature branches
+> but not directly to `master` (which is branch-protected). If you
+> need master baselines refreshed, dispatch on a feature branch and
+> open a PR; the bot writes there, the PR carries it through.
+
+Always include the *why* in the commit / PR body — a baseline change
+is a visual contract change, and reviewers can't tell from the .png
+alone whether the diff is intended.
 
 ## What to add when
 
@@ -186,8 +209,9 @@ whether the diff is intended.
   outcome; mocking Chart.js's internal APIs adds setup without
   payoff.
 - **Real Home Assistant frontend.** Specs run against the mock; HA
-  integration is verified manually on a Pi smoke test (CLAUDE.md has
-  the procedure).
+  integration is verified manually against a real HA instance — see
+  [LOCAL-TESTING.md](LOCAL-TESTING.md) for the Docker recipe that
+  doesn't depend on any maintainer-specific setup.
 - **Cross-browser visual regression.** One project (Chromium) is
   sufficient: HA frontend itself targets Chromium-class browsers,
   and baselines pinned to a single rendering engine sidestep

--- a/docs/QUALITY-GATES.md
+++ b/docs/QUALITY-GATES.md
@@ -1,0 +1,158 @@
+# Quality gates
+
+Build-time and CI gates that every PR has to clear. Most are
+mechanical (lint passes, tests pass, coverage stays above the floor);
+a few have load-bearing rationale that's worth knowing before you
+touch them.
+
+→ Back to [README](../README.md)
+
+## What runs in CI
+
+Two GitHub Actions checks are required before the merge button
+activates on `master`:
+
+- **`build`** (`.github/workflows/build.yml`) — chains lint, audit,
+  typecheck, vitest unit tests + coverage, dependency-cruiser,
+  rollup, e2e + visual regression, and the dist-in-sync verification.
+- **`Analyze (javascript-typescript)`** (CodeQL) — security analysis
+  on `security-extended` queries.
+
+SonarCloud and Dependabot also run on PRs but are advisory; the
+standalone `CodeQL` helper status is also non-required (the
+`Analyze` job is the gate).
+
+## Lint — ESLint 10 (flat config)
+
+Configured in `eslint.config.mjs` with `typescript-eslint`,
+`eslint-plugin-lit`, and `eslint-plugin-sonarjs`. **0 errors** is
+required to ship; warnings are an accepted refactoring backlog
+(currently ~60, mostly cognitive-complexity in the integration
+boundary `main.ts` plus `scroll-ux.ts` and `sunshine-source.ts`).
+
+The convention for promoting `warn → error` per rule is "do it once
+the hot-spot is refactored" — flipping a warning to error before the
+refactor would block PRs that didn't introduce the warning.
+
+**Don't blanket-run `eslint --fix`.** It once removed an
+`as HTMLCanvasElement` cast in `chart/orchestrator.ts` that the
+typecheck depended on; the build broke. Fix targeted lints by hand
+or `--fix --rule <id>` for one rule at a time, and re-run typecheck
+after.
+
+## npm audit
+
+`npm audit --audit-level=high` runs in CI and blocks the build on
+high or critical advisories. Lower severities are reported by
+Dependabot but don't fail the build.
+
+## Coverage gate
+
+CI fails if statements / branches / functions / lines drop below
+**80 %** for the modules in `vitest.config.js`. Editor + `main.ts`
+are out of scope (covered by Playwright instead).
+
+> **History note.** Pre-v1.4.2 the `include` array in
+> `vitest.config.js` listed `.js` paths after the v1.2 TypeScript
+> migration. The v8 coverage provider matched zero files and the
+> gate was silently inert (`Statements 0/0 (Unknown%)`) for several
+> releases. If you ever touch the coverage config and the report
+> looks suspiciously easy to pass, check whether the include
+> patterns are actually matching files before celebrating.
+
+## Architecture rules — dependency-cruiser
+
+`.dependency-cruiser.cjs` enforces:
+
+- **No circular imports** project-wide.
+- **No orphans** under `src/` (a file nothing imports is a finding).
+  `teardown-registry.ts` is allow-listed as the documented exception —
+  test-covered, slated for re-integration in a future cycle.
+- **Module boundaries**: `src/chart/`, `src/editor/`, and `src/utils/`
+  may not uplevel-import. A new `import "../../something"` in those
+  subtrees is a finding.
+
+## SonarCloud
+
+Active since 2026-05-07. Project key
+`chriguschneider_weather-station-card`, organisation `chriguschneider`,
+secret `SONAR_TOKEN`. Automatic Analysis is **off** — the CI-driven
+scan is the source of truth (the two collide otherwise). LCOV from
+`npm run coverage` feeds the dashboard. Quality-gate status is shown
+in PRs but not required for merge.
+
+A few file-scoped exclusions live in `sonar-project.properties`:
+
+- `src/main.ts` excluded from analysis (HA integration boundary,
+  uses `@ts-nocheck` per ADR-0004).
+- Several modules excluded from coverage scope where Playwright is
+  the test harness (mirror `vitest.config.js` `coverage.include`).
+- `src/locale.ts` excluded from CPD (per-language string tables
+  intentionally repeat units / cardinal-direction / condition-id
+  blocks — see issue #123).
+- `typescript:S3735` (void operator) suppressed project-wide because
+  the void-floating-promise pattern is what `typescript-eslint`'s
+  `no-floating-promises` actively requires (see issue #57).
+
+## CodeQL
+
+Runs `security-extended` queries weekly and on every PR via
+`.github/workflows/codeql.yml`. The `Analyze (javascript-typescript)`
+job is the required check; the standalone `CodeQL` helper is
+advisory.
+
+## Dependabot
+
+`.github/dependabot.yml` opens weekly PRs for npm and GitHub Actions
+updates. **No auto-merge** — every PR gets a manual review.
+
+Two patterns to watch for:
+
+- **Major version bumps.** Always read the changelog before merging;
+  even with a green CI a major release can introduce silent
+  behavioural changes that the test suite doesn't yet exercise.
+- **Wrapper-deprecation on Actions.** Some GHA actions become thin
+  wrappers around their successor (e.g.
+  `sonarsource/sonarcloud-github-action` v5 was a wrapper around
+  `SonarSource/sonarqube-scan-action`). When Dependabot proposes a
+  major bump, also check whether the action itself is deprecated —
+  if so, switch to the successor directly and close the Dependabot
+  PR.
+
+## Branch protection
+
+`master` is protected since 2026-05-07. Required status checks:
+`build` and `Analyze (javascript-typescript)`. PR required, linear
+history required, no force-push, no delete. `enforce_admins: false`
+means the maintainer can bypass via the GitHub UI in a true
+emergency, but contributors should always use the PR flow.
+
+The protection means even bot-generated commits (e.g. baseline
+regen via `update-baselines.yml`) need to land via PR if they
+target master directly. The current workflow dispatches on a
+feature branch and the bot pushes to that branch; a follow-up PR
+moves the baselines onto master.
+
+## dist/ in sync
+
+The `verify dist matches HEAD` step in `build` re-runs the bundler in
+CI and compares the output against the committed
+`dist/weather-station-card.js`. If `src/**/*.ts` is staged without a
+matching `dist/` rebuild, this step fails with a clear error.
+
+The architectural reason for committing the bundle lives in
+[ADR-0001 (dist committed for HACS)](adr/0001-dist-committed-for-hacs.md).
+Resolving rebase conflicts in the minified bundle is documented in
+[`AGENTS.md`](../AGENTS.md#resolving-dist-conflicts-on-rebase).
+
+## E2E baseline regeneration
+
+Visual-regression baselines under `tests-e2e/snapshots/` are
+regenerated only via the `update-baselines.yml` GHA workflow (see
+[ADR-0003](adr/0003-e2e-baselines-pinned-to-gha.md)). Local
+Playwright runs use a different rendering environment and produce
+diffs of 1–4 % against the GHA-pinned baselines, well past the
+0.2 % tolerance — never commit locally regenerated PNGs.
+
+[`TESTING.md`](../TESTING.md#updating-visual-baselines) has the dispatch
+recipe.

--- a/docs/STYLE-GUIDE.md
+++ b/docs/STYLE-GUIDE.md
@@ -173,6 +173,24 @@ For light/dark adaptive rendering on GitHub:
 
 All images carry meaningful `alt` text.
 
+### HACS sanitizer constraints
+
+`README.md` is also rendered inside the HACS info panel, which
+sanitises the markdown more aggressively than GitHub does. Two
+patterns that work on GitHub but get dropped by HACS:
+
+- **`<picture>` / `<source>` tags.** The sanitiser strips them, leaving
+  only the `<img>` fallback. Use plain `<img>` in `README.md` even
+  if it costs the light/dark adaptive rendering — the HACS info-panel
+  reader is the lower-common-denominator audience.
+- **Relative image paths.** Resolve from the GitHub URL, not the HACS
+  install. Always use absolute
+  `https://raw.githubusercontent.com/<owner>/<repo>/master/...` URLs
+  for any image referenced from `README.md`.
+
+Other docs (`docs/*.md`, `CONTRIBUTING.md`, etc.) are GitHub-only
+and aren't affected — `<picture>` and relative paths are fine there.
+
 ## Card colour tokens
 
 Single source of truth for the card's visual colours. Every concept

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -72,6 +72,15 @@ render tick. If a field doesn't seem to update:
   string `'25'` instead of the number `25`; the card coerces, but if you
   see a chart sized oddly, check the YAML view for stray quotes.
 
+## Tap / hold action does nothing in the editor preview
+
+The card-configuration dialog renders a live preview of the card on
+the right side. `tap_action`, `hold_action`, and `double_tap_action`
+all *fire* in the preview — but the visual side effects of `navigate`
+or `url` actions are obscured by the dialog overlay. If you're testing
+a navigation action and nothing seems to happen, close the editor and
+try the action on the real dashboard.
+
 ## Removed in v1.9.x
 
 The following config keys no longer exist in the code path. Old YAML

--- a/docs/adr/0006-build-time-version-injection.md
+++ b/docs/adr/0006-build-time-version-injection.md
@@ -31,7 +31,7 @@ Alternatives considered:
   it just fails the build instead of silently shipping a stale banner.
 - **Add `@rollup/plugin-replace` as a dependency.** The standard way
   to inject build-time constants. Works, but adds a dep to the build
-  graph for one trivial substitution. Per CLAUDE.md's quality stack,
+  graph for one trivial substitution. Per [docs/QUALITY-GATES.md](../QUALITY-GATES.md#dependabot),
   major-version bumps need manual changelog review; even a minor dep
   add is non-trivial.
 - **Inline Rollup transform plugin (no new dep).** A small object with

--- a/docs/adr/0007-set-hass-three-phase.md
+++ b/docs/adr/0007-set-hass-three-phase.md
@@ -24,8 +24,8 @@ that did three logically distinct things in one body:
 The function shared local helpers (`stateOf`, `valueOf`, `attrOf`,
 `fromWxIfMissing`) across all three phases. ESLint
 `sonarjs/cognitive-complexity` flagged it as warn-level
-(CLAUDE.md describes the v1.4.2 backlog of ~123 such warnings as
-"accepted refactoring debt"). It was hard to reason about in isolation
+(see [docs/QUALITY-GATES.md → Lint](../QUALITY-GATES.md#lint--eslint-10-flat-config)
+for how the warning backlog is managed). It was hard to reason about in isolation
 — a change to memoization had to acknowledge the surrounding
 subscription churn; a change to subscription teardown had to step over
 ~80 lines of classifier logic.


### PR DESCRIPTION
## Summary

Closes #131. Spun off from #127 (the synthesis comment's aggressive-split decision).

Two new tracked docs land at canonical locations, content migrates out of the gitignored `CLAUDE.md`, and four references that pointed at the gitignored file are fixed.

## New files

- **`AGENTS.md`** (~130 lines, repo root) — conventions specific to AI-assisted contributions: commit-attribution trailer pattern, comment discipline with examples, ADR-trigger pointer, `.claude/skills/` note for Claude Code users vs. other tools, parallel-work branch naming + issue claiming, draft-PR convention, `dist/` rebase recipe, link to LOCAL-TESTING.md (#130).
- **`docs/QUALITY-GATES.md`** (~160 lines) — full reference for the v1.4.2 quality stack: ESLint warning-backlog policy, npm audit, coverage gate (with the silently-inert lesson from pre-v1.4.2), dependency-cruiser boundaries, SonarCloud setup + exclusions including the new ones from #57 / #123, CodeQL, Dependabot review conventions including the GHA wrapper-deprecation pattern, branch-protection rules, dist-in-sync verification, and pointer to the e2e baseline regen workflow.

## Migrated content (CLAUDE.md content now in tracked docs)

- Editor-preview tap/hold gotcha → `docs/TROUBLESHOOTING.md`.
- HACS sanitizer constraint (no `<picture>`/`<source>`, absolute raw URLs) → `docs/STYLE-GUIDE.md` "Image conventions" section.
- E2E-baselines GHA-pinned policy + dispatch recipe → `TESTING.md` "Updating visual baselines" subsection (with an anchor for the AGENTS.md / QUALITY-GATES.md backlinks).
- AGENTS.md pointer + QUALITY-GATES.md pointer → `CONTRIBUTING.md`.

## Broken-reference cleanup (4 sites)

| File | Was | Now |
| --- | --- | --- |
| `.github/PULL_REQUEST_TEMPLATE.md:16` | `Smoke-tested on Pi (Pi setup is in CLAUDE.md)` | `Smoke-tested locally (see LOCAL-TESTING.md ... maintainers may use a live HA instance)` |
| `TESTING.md:189` | `…verified manually on a Pi smoke test (CLAUDE.md has the procedure)` | `…verified manually against a real HA instance — see LOCAL-TESTING.md` |
| `docs/adr/0006:34` | `Per CLAUDE.md's quality stack, major-version bumps need…` | `Per docs/QUALITY-GATES.md#dependabot, major-version bumps need…` |
| `docs/adr/0007:27` | `(CLAUDE.md describes the v1.4.2 backlog of ~123 such warnings as "accepted refactoring debt")` | `(see docs/QUALITY-GATES.md#lint--eslint-10-flat-config for how the warning backlog is managed)` |

## CLAUDE.md (gitignored, not in this PR diff)

Shrunk locally from 298 → 87 lines. Kept only genuinely per-machine content: chrigu's identity, HA location, Pi SSH recipe, WSL credentials, sandbox notes. The ≤ 60 line target from the issue acceptance is overshot because the Pi SSH recipe and WSL block are themselves substantial — both are kept because they don't generalise.

## Out of scope (per the #127 synthesis)

- Worktree-skill automation (the existing skills don't grow new triggers).
- Issue-claiming-skill automation (deferred until friction shows up).
- ADR-0001 amendment for the dist-in-tree decision (the rebase-and-rebuild discipline is documented in AGENTS.md; the decision itself stands).

## Memory cleanup

After this lands, the two project-wide memory files at `~/.claude/projects/C--Code-weather-station-card/memory/` (`quality_stack_v142.md` and `hacs_readme_constraints.md`) become redundant — their content lives in the tracked docs above. I'll delete them after merge.

## Test plan

- [ ] CI green — pure docs change (lint + typecheck + tests are unaffected, but `verify dist matches HEAD` should be uneventful since src/ wasn't touched)
- [ ] Spot-check that the 4 fixed references resolve to the right anchors after merge
- [ ] (Optional) Browse AGENTS.md and QUALITY-GATES.md from the GitHub UI to verify table-of-contents and cross-links render

🤖 Generated with [Claude Code](https://claude.com/claude-code)