### PR TITLE
chore(src): drop historical comment scaffolding (#125)

### DIFF
--- a/dist/weather-station-card.js
+++ b/dist/weather-station-card.js
@@ -28,8 +28,8 @@
           border-bottom: 1px solid var(--divider-color);
         }
         h3.section:first-of-type { margin-top: 0; }
-        /* Section headers with the v1.10.2 reset-to-defaults icon
-           button. The button right-aligns in the heading; clicking it
+        /* Section headers with the reset-to-defaults icon button.
+           The button right-aligns in the heading; clicking it
            drops every key the section owns from this._config so DEFAULTS
            take over. */
         h3.section.section-header-with-reset {

--- a/src/action-handler.ts
+++ b/src/action-handler.ts
@@ -1,15 +1,7 @@
 // Whole-card action handler: pointer-based tap / hold / double-tap
 // detection on the ha-card root, plus the HA-action dispatcher that
-// it fires.
-//
-// Lifted out of main.js in v1.1 — previously these were two methods
-// (_setupActionHandler, _runAction) with intertwined comments that
-// drifted next to scroll-ux during earlier refactors. Coupling to the
-// card instance: card.shadowRoot (cursor + listener attach), card.config
-// (action map + cursor decision), card._hass (callService),
-// card._fire (event dispatch), card._dragMoved (read — drag-to-scroll
-// suppresses the trailing tap/hold), card._actionHandlerTeardown
-// (mutated for the disconnectedCallback path).
+// it fires. Shares `_dragMoved` with scroll-ux so a drag-to-scroll
+// suppresses the trailing tap.
 //
 // Why pointer events vs. plain click: we need hold detection (fires
 // before pointerup) and a way to suppress the trailing tap. A 250 ms

--- a/src/chart/draw.ts
+++ b/src/chart/draw.ts
@@ -1,9 +1,5 @@
-// Chart.js instance builder. Pulled out of main.js so the lifecycle
-// component (set hass / updated / render / drawChart) and the chart
-// configuration each fit in one screen of mental model.
-//
-// Inputs are passed as a single bag so the call site (drawChart in
-// main.js) reads as a small list of "what does the chart need to know"
+// Chart.js instance builder. Inputs are passed as a single bag so the
+// call site reads as a small list of "what does the chart need to know"
 // instead of a 200-line block of nested options.
 //
 // Chart.js's own option types are deeply generic (`Chart<TType, TData,
@@ -70,10 +66,10 @@ export function buildChart(ctx: CanvasRenderingContext2D | HTMLCanvasElement, op
     },
     options: {
       maintainAspectRatio: false,
-      // Default Chart.js animation is 1000 ms easeOutQuart. With the
-      // post-v0.9 dataset density (precip + sunshine = up to 336 bars
-      // animating in hourly mode), 1 s feels laggy. 500 ms still reads
-      // as a transition without dragging. Users who want it fully off
+      // Default Chart.js animation is 1000 ms easeOutQuart. With dataset
+      // density up to 336 bars (precip + sunshine in hourly mode), 1 s
+      // feels laggy. 500 ms still reads as a transition without dragging.
+      // Users who want it fully off
       // continue to set `forecast.disable_animation: true`. The
       // editor's live preview also forces 0 ms (inPreview from main.ts'
       // connectedCallback ancestor walk) so each editor toggle renders

--- a/src/chart/orchestrator.ts
+++ b/src/chart/orchestrator.ts
@@ -1,8 +1,5 @@
 // Chart orchestration: takes the card's `forecasts` + config and
-// produces a configured Chart.js instance. Lifted out of main.js
-// in v1.1 — was the largest method on the card class (~290 LOC of
-// dataset / plugin / segment-options assembly intermixed with
-// canvas lookup and Chart.defaults global mutation).
+// produces a configured Chart.js instance.
 //
 // Responsibilities:
 //   - normalize the config (forecast.type fallback for typo'd YAML)
@@ -518,7 +515,7 @@ export function drawChartUnsafe(card: CardLike, args: DrawChartArgs | null): unk
   // pixels via afterFit. dailyTickLabelsPlugin then shifts weekday + date
   // up by that amount so the new bottom strip is free for the sunshine
   // box. When sunshine is off, sunshineLabelBand stays 0 and chart
-  // layout is byte-identical to v0.8.
+  // layout is unchanged.
   const labelsBaseSize = parseInt(String(config.forecast.labels_font_size)) || 11;
   const sunshineLabelBand = showSunshineLabels ? Math.max(16, labelsBaseSize + 6) : 0;
 

--- a/src/chart/plugins.ts
+++ b/src/chart/plugins.ts
@@ -1,12 +1,6 @@
 // Barrel re-export for the Chart.js plugin factories. The factories
 // themselves live one file per plugin under chart/plugins/ — see
-// the header comment in each file for the rendering contract. The
-// split (#57) trimmed the previously-monolithic 600-line file and
-// reduced the cognitive complexity of the dailyTickLabels afterDraw
-// hook from 46 to under 15 by extracting its two render branches.
-//
-// Existing imports from `'./chart/plugins.js'` keep working without
-// edits — the barrel preserves the public API.
+// the header comment in each file for the rendering contract.
 
 export type {
   ChartScaleLike,

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -69,9 +69,9 @@ export interface DataSourceConfig {
   forecast?: { type?: 'daily' | 'hourly' | 'today' } | null;
   sensors?: SensorMap;
   condition_mapping?: ConditionThresholdOverrides & {
-    /** Threshold for the Method-B2 lux-derivation (#66): a sample
-     *  counts as sunshine when `measured_lux / clearsky_lux ≥ this`.
-     *  Default 0.6 per the #6 spec. */
+    /** Threshold for the Method-B2 lux-derivation: a sample counts
+     *  as sunshine when `measured_lux / clearsky_lux ≥ this`.
+     *  Default 0.6. */
     sunshine_lux_ratio?: number;
   };
   weather_entity?: string;
@@ -223,7 +223,7 @@ export class MeasuredDataSource {
     if (!this.hass) return [];
     const cfgDays = parseInt(String(this.config.days), 10) || 7;
     const type = this.config.forecast?.type;
-    // 'today' is the 24-hour zoom mode (#17): hourly granularity but
+    // 'today' is the 24-hour zoom mode: hourly granularity but
     // forced to a single-day horizon regardless of the user's `days:`
     // setting. Reuses the entire hourly fetch / build path.
     const isToday = type === 'today';
@@ -289,7 +289,7 @@ export class MeasuredDataSource {
       types: ['min', 'max', 'mean', 'change', 'sum'],
     });
 
-    // Method B2 fallback (#66): when the user has an illuminance sensor
+    // Method B2 fallback: when the user has an illuminance sensor
     // configured but no `sensors.sunshine_duration`, derive sunshine
     // duration from the high-resolution illuminance history via the
     // lux/clearsky_lux ratio. Skipped silently if either input is
@@ -299,8 +299,8 @@ export class MeasuredDataSource {
     return this._buildForecast(stats, sensors, start, days, luxByDate);
   }
 
-  /** B2 past-tier helper (#66): fetch the configured illuminance
-   *  sensor's high-resolution history and convert it into a per-day
+  /** B2 past-tier helper: fetch the configured illuminance sensor's
+   *  high-resolution history and convert it into a per-day
    *  sunshine-hours map. Returns `null` when the path is inapplicable
    *  (no illuminance sensor, recorder sensor takes precedence, or
    *  the WS call fails) so the caller can short-circuit to the next
@@ -432,7 +432,7 @@ export class MeasuredDataSource {
       let sunshineRaw = sensors.sunshine_duration
         ? at(sensors.sunshine_duration, 'max')
         : null;
-      // B2 fallback (#66): when no recorder sunshine sensor resolved
+      // B2 fallback: when no recorder sunshine sensor resolved
       // a value, look up the per-day total from the lux-derivation
       // map computed from the illuminance sensor's history. The
       // map's date key is `YYYY-MM-DD` in the local timezone — same
@@ -493,8 +493,7 @@ export class MeasuredDataSource {
    *      computed for the actual hour rather than the day's noon, so
    *      the cloud-cover ratio reflects the relevant solar geometry.
    *      Threshold semantics (rainy_threshold_mm etc.) are kept as-is
-   *      and known to be conservative at hour scale — refining hourly
-   *      thresholds is tracked as a v0.9 issue. */
+   *      and known to be conservative at hour scale. */
   private _buildHourlyForecast(
     stats: StatsResponse,
     sensors: SensorMap,

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -12,15 +12,14 @@ export const DEFAULTS_FORECAST = {
   style: 'style2',
   // Concept-colour defaults are literal RGBA strings.
   //
-  // Theme tokens were tried in v1.9.0 (--warning-color for sunshine,
-  // --info-color for low temp, --state-sensor-*-color for the rest),
-  // but two failure modes surfaced. The "warning"-shaped tokens are
-  // semantic mismatches — --warning-color is HA's alert orange/red,
-  // not "sunshine" (#121); --info-color is for info banners, not
-  // "cold" — and the --state-sensor-*-color tokens we picked don't
-  // actually exist in HA's frontend at all (verified via
-  // home-assistant/frontend code search), so the var() wrapper was
-  // dead weight that only obscured the literal.
+  // Theme tokens were tried (--warning-color for sunshine, --info-color
+  // for low temp, --state-sensor-*-color for the rest), but two failure
+  // modes surfaced. The "warning"-shaped tokens are semantic mismatches
+  // — --warning-color is HA's alert orange/red, not "sunshine";
+  // --info-color is for info banners, not "cold" — and the
+  // --state-sensor-*-color tokens we picked don't actually exist in HA's
+  // frontend at all (verified via home-assistant/frontend code search),
+  // so the var() wrapper was dead weight that only obscured the literal.
   //
   // Users who want theme-driven colours can still pass their own
   // var(...) string in YAML — resolveCssVar resolves user input the
@@ -32,9 +31,9 @@ export const DEFAULTS_FORECAST = {
   show_sunshine: false,
   sunshine_color: 'rgba(255, 215, 0, 1.0)',
   condition_icons: true,
-  // DEPRECATED v1.9.x — see renderWind in main.ts. Kept as a hard
-  // master-off shim for v1.x YAML configs with show_wind_forecast:
-  // false; slated for removal in v2.0. New installs should not set it.
+  // Deprecated — see renderWind in main.ts. Kept as a hard master-off
+  // shim for YAML configs that explicitly set show_wind_forecast:
+  // false; new installs should not set it.
   show_wind_forecast: true,
   show_wind_arrow: true,
   show_wind_speed: true,
@@ -75,8 +74,8 @@ export const DEFAULTS = {
   show_sun: false,
   show_dew_point: false,
   show_wind_gust_speed: false,
-  // UV index defaults to true to preserve v1.x behaviour where UV was
-  // always shown if a sensor was wired. The other three new attribute
+  // UV index defaults to true to preserve the original behaviour where
+  // UV was always shown if a sensor was wired. The other three attribute
   // cells default to false so existing layouts don't suddenly grow.
   show_uv_index: true,
   show_illuminance: false,

--- a/src/editor/render-chart.ts
+++ b/src/editor/render-chart.ts
@@ -8,8 +8,8 @@
 // Always visible — the chart renders in every mode (station = past
 // chart, forecast = future chart, combination = both side-by-side).
 //
-// Schema-driven via <ha-form> (#87, v1.10.2). Three logical groups,
-// each its own form so the visual subsection headings stay between:
+// Schema-driven via <ha-form>. Three logical groups, each its own form
+// so the visual subsection headings stay between:
 //   - Title + time range (top-level + forecast.number_of_forecasts)
 //   - Chart rows (forecast.* booleans)
 //   - Style (forecast.style + 2 forecast.* booleans)

--- a/src/editor/render-live-panel.ts
+++ b/src/editor/render-live-panel.ts
@@ -10,8 +10,8 @@
 // Always visible — show_main is the gate for the panel itself; users
 // can keep it off in pure forecast mode if they prefer the chart alone.
 //
-// Schema-driven via <ha-form> (#87, v1.10.2). Two ha-form blocks split
-// the section visually:
+// Schema-driven via <ha-form>. Two ha-form blocks split the section
+// visually:
 //   - Main panel: show_main + 6 sub-toggles (time-related toggles
 //     conditionally appear)
 //   - Attributes: show_attributes + 10 sub-toggles (each conditional

--- a/src/editor/section-header.ts
+++ b/src/editor/section-header.ts
@@ -1,6 +1,6 @@
-// Shared render helper for editor section headings (v1.10.2 #92).
-// Each section's `<h3 class="section">` is wrapped with this helper so
-// the reset-to-defaults icon button appears uniformly across all 7
+// Shared render helper for editor section headings. Each section's
+// `<h3 class="section">` is wrapped with this helper so the
+// reset-to-defaults icon button appears uniformly across all 7
 // sections. Click → editor._resetSection(sectionKey) → SECTION_KEYS
 // lookup → delete keys from config → DEFAULTS take over.
 

--- a/src/editor/section-keys.ts
+++ b/src/editor/section-keys.ts
@@ -1,6 +1,6 @@
-// Per-section config-key inventories for the v1.10.2 #92 reset-to-
-// defaults buttons. Each entry lists the FULL possible set of keys the
-// section owns — including conditionally-rendered ones. _resetSection
+// Per-section config-key inventories for the reset-to-defaults
+// buttons. Each entry lists the FULL possible set of keys the section
+// owns — including conditionally-rendered ones. _resetSection
 // iterates the list and deletes each key from this._config (lets DEFAULTS
 // take over on the next render).
 //

--- a/src/forecast-utils.ts
+++ b/src/forecast-utils.ts
@@ -130,11 +130,9 @@ interface HourlyTempSeriesResult {
  *  hide / skip the second dataset instead of pushing an empty array
  *  (which would otherwise leave a dangling legend / pointless gap).
  *
- *  History (v1.0.1): the previous "all-or-nothing" rule (any null →
- *  tempLow returned as null entirely) hid the low-temp line in
- *  combination + station modes whenever a single past day had a
- *  missing min reading. Switched to "some have low" so a single
- *  offline day shows as a gap, not as a vanished dataset. */
+ *  Use "some have low" rather than all-or-nothing: a single offline
+ *  day shows as a gap, not as a vanished dataset across combination +
+ *  station modes. */
 export function hourlyTempSeries(
   entries: ReadonlyArray<Partial<ForecastEntry>>,
   opts: HourlyTempSeriesOpts = {},
@@ -217,7 +215,7 @@ export function nextForecastType(current: string | undefined | null): 'daily' | 
   return 'today';
 }
 
-/** Lazy-cache key for the MeasuredDataSource's recorder fetch (#10).
+/** Lazy-cache key for the MeasuredDataSource's recorder fetch.
  *  Both 'hourly' and 'today' fetch the same hourly buckets — the
  *  difference is purely render-time aggregation — so they share a
  *  cache slot. Toggling between hourly and today therefore needs no
@@ -236,7 +234,7 @@ export function forecastFetchKey(cfg: { forecast?: { type?: string } | null } | 
 }
 
 /** Estimate sunshine duration in hours from a forecast's cloud-coverage
- *  fraction (#6 Option F3 — Kasten-style empirical formula).
+ *  fraction (Kasten-style empirical formula).
  *
  *    sunshine_h ≈ day_length × (1 − (cloud_coverage / 100)^p)
  *
@@ -273,7 +271,7 @@ export function sunshineFromCloudCoverage(
 }
 
 /** Structural deep-equality for two forecast arrays. Used by the data
- *  source subscribe callbacks (#55) to skip re-renders when HA's
+ *  source subscribe callbacks to skip re-renders when HA's
  *  WebSocket layer fan-outs an identical payload — common when one
  *  card's resubscribe causes HA to broadcast the entity's current
  *  state to every subscriber of that entity, including sibling

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -144,19 +144,19 @@ const locale: Locale = {
       'style_heading': 'Stil & Farben',
       'units_heading': 'Einheiten',
       'advanced_heading': 'Erweitert',
-      // v1.10 section headings — top-level
+      // Section headings — top-level
       'card_setup_heading': 'Karte einrichten',
       'station_sensors_heading': 'Sensoren deiner Wetterstation',
       'weather_forecast_heading': 'Wettervorhersage',
       'chart_section_heading': 'Diagramm',
       'live_panel_heading': 'Live-Anzeige',
       'actions_section_heading': 'Aktionen',
-      // v1.10.2 — per-section reset-to-defaults button (#92)
+      // Per-section reset-to-defaults button
       'reset_section': 'Diese Sektion auf Standardwerte zurücksetzen',
-      // v1.10 sub-section headings
+      // Sub-section headings
       'chart_time_range_heading': 'Zeitraum & Auflösung',
-      // v1.9 keys retained for backwards compatibility (third-party
-      // translations that have been updated for v1.9 keep working).
+      // Keys retained for backwards compatibility (third-party
+      // translations that target the previous schema keep working).
       'mode_question_heading': 'Was zeigt die Karte?',
       'display_question_heading': 'Was wird angezeigt?',
       'appearance_heading': 'Aussehen',
@@ -317,23 +317,23 @@ const locale: Locale = {
       'style_heading': 'Style & Colours',
       'units_heading': 'Units',
       'advanced_heading': 'Advanced',
-      // v1.10 section headings — top-level
+      // Section headings — top-level
       'card_setup_heading': 'Card setup',
       'station_sensors_heading': 'Your weather station\'s sensors',
       'weather_forecast_heading': 'Weather forecast',
       'chart_section_heading': 'Chart',
       'live_panel_heading': 'Live panel',
       'actions_section_heading': 'Actions',
-      // v1.10.2 — per-section reset-to-defaults button (#92)
+      // Per-section reset-to-defaults button
       'reset_section': 'Reset this section to defaults',
-      // v1.10 sub-section headings
+      // Sub-section headings
       'chart_time_range_heading': 'Time range & resolution',
-      // v1.9 keys retained for backwards compatibility.
+      // Keys retained for backwards compatibility.
       'mode_question_heading': 'What this card shows',
       'display_question_heading': 'What gets shown',
       'appearance_heading': 'Appearance',
       'tap_behavior_heading': 'Tap behavior',
-      // Legacy keys (kept so old translations keep working in v0.6)
+      // Legacy keys (kept so older translations keep working).
       'card_heading': 'Card',
       'display_heading': 'Display',
       'chart_heading': 'Chart',
@@ -342,7 +342,7 @@ const locale: Locale = {
       'mode_station': 'Station only',
       'mode_forecast': 'Forecast only',
       'mode_combination': 'Station and Forecast Combined',
-      // Chart type radio (v0.8 — re-introduced)
+      // Chart type radio
       'chart_type_label': 'Chart type',
       'forecast_type_daily': 'Daily',
       'forecast_type_today': 'Today (24h)',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,27 +1,25 @@
-// main.ts — integration boundary file. ~1500 LOC of LitElement +
-// Home Assistant + Chart.js wiring. Type-checked under `tsc --strict`
-// since v1.8 (#33). HA-shaped fields use the `HassMain` extension of
-// the data-source `HassLike` type below — full HomeAssistant type
-// would pull in too many UI deps. Anything where the HA frontend
-// type-shape isn't documented (synthesised `weather`, editor-callback
-// payloads) is `any`-typed, with eslint-disable lines limited to
-// those exact slots.
+// main.ts — integration boundary file. LitElement + Home Assistant +
+// Chart.js wiring, type-checked under `tsc --strict`. HA-shaped fields
+// use the `HassMain` extension of the data-source `HassLike` type below
+// — the full HomeAssistant type would pull in too many UI deps.
+// Anything where the HA frontend type-shape isn't documented
+// (synthesised `weather`, editor-callback payloads) is `any`-typed,
+// with eslint-disable lines limited to those exact slots.
 //
-// Why the opt-out: this class touches ~30 instance fields (forecasts,
-// weather, current sensor readings, scroll-ux teardowns, animation
-// controllers, …), most of which were declared implicitly via runtime
-// assignment in `set hass` / `setConfig`. Strict-typing them all means
-// porting half a dozen HA frontend type imports we don't currently
-// depend on, mocking them where the types are missing, and threading
-// `HassLike` through the entire render path. None of that adds value
-// to the v1.2 milestone, which is "the codebase compiles under TS and
-// downstream contributors get types when they import from us".
+// Why the opt-out on stricter typing: this class touches ~30 instance
+// fields (forecasts, weather, current sensor readings, scroll-ux
+// teardowns, animation controllers, …), most of which were declared
+// implicitly via runtime assignment in `set hass` / `setConfig`.
+// Strict-typing them all means porting half a dozen HA frontend type
+// imports we don't currently depend on, mocking them where the types
+// are missing, and threading `HassLike` through the entire render path
+// — without adding value to the goal of "the codebase compiles under TS
+// and downstream contributors get types when they import from us".
 //
 // The boundary modules main.ts pulls in (data-source, chart/*,
 // sunshine-source, openmeteo-source, scroll-ux, action-handler,
 // editor/*) ARE all strictly typed — anyone importing from this card
-// gets typed exports. Tightening main.ts itself is tracked as future
-// follow-up.
+// gets typed exports.
 
 import locale from './locale.js';
 import {
@@ -609,7 +607,7 @@ _syncDataSources(hass: HassMain): void {
           const newData = event.forecast || [];
           const newError = event.error || null;
           // Skip the re-render path when HA's WS layer fan-outs an
-          // identical payload (#55) — common when a sibling card on
+          // identical payload — common when a sibling card on
           // the same dashboard resubscribes against the same recorder
           // bucket and HA broadcasts the cached state to every
           // subscriber. The error string flips equally rarely so an
@@ -640,7 +638,7 @@ _syncDataSources(hass: HassMain): void {
         try {
           const newData = event.forecast || [];
           const newError = event.error || null;
-          // Same fan-out suppression as the station path above (#55).
+          // Same fan-out suppression as the station path above.
           // weather/subscribe_forecast in HA fan-outs the entity's
           // current forecast to every active subscriber whenever
           // any one of them (re)subscribes — without this guard, a
@@ -684,7 +682,7 @@ _syncDataSources(hass: HassMain): void {
     this.resizeObserver = null;
     this.resizeInitialized = false;
     this._teardownRegistry = new TeardownRegistry();
-    // Lazy-cache (#10): when forecast.type changes, save the current
+    // Lazy-cache: when forecast.type changes, save the current
     // data under the OLD fetch-key and restore the NEW key from cache
     // for an instant render. Fresh data lands on the resubscribe
     // callback and overwrites the cached entry.
@@ -858,7 +856,7 @@ _syncDataSources(hass: HassMain): void {
   }
 
   // Daily / hourly flow: overlay sunshine at the matching granularity.
-  // F3 fallback (#6): when neither sensor.sunshine_duration nor Open-Meteo
+  // F3 fallback: when neither sensor.sunshine_duration nor Open-Meteo
   // resolves a forecast value, the configured exponent
   // (default 1.7, tunable via condition_mapping.sunshine_cloud_exponent)
   // lets attachSunshine derive the value from forecast.cloud_coverage via
@@ -972,11 +970,12 @@ measureCard() {
   const card = safeQuery(this.shadowRoot,'ha-card');
   if (!card) return;
 
-  // forecastItems is the count of bars actually rendered. v0.8 treats
-  // forecast.number_of_forecasts as a *viewport size* (handled in render
-  // via overflow-x scroll), not as a data-cropping cap — so this always
-  // renders the full series. Width-based auto-fit only kicks in when no
-  // data is loaded yet (initial render before the data sources fire).
+  // forecastItems is the count of bars actually rendered. The card
+  // treats forecast.number_of_forecasts as a *viewport size* (handled
+  // in render via overflow-x scroll), not as a data-cropping cap — so
+  // this always renders the full series. Width-based auto-fit only
+  // kicks in when no data is loaded yet (initial render before the
+  // data sources fire).
   if (this.forecasts?.length) {
     this.forecastItems = this.forecasts.length;
   } else {
@@ -1119,11 +1118,10 @@ async updated(changedProperties: Map<PropertyKey, unknown>) {
   // weather-undefined fallback uses a different template than the
   // populated branch); the per-element _wsActionHandlerBound flag
   // makes this idempotent on stable elements.
-  // The card class has all the fields these helpers need (verified at
-  // runtime by the v0.6 extraction); the structural-mismatch errors come
-  // from the helpers' tighter `forecasts: ForecastEntry[]` and config
-  // shapes. Cast through `unknown` to keep tsc happy while preserving
-  // the runtime assumption.
+  // The card class has all the fields these helpers need; the
+  // structural-mismatch errors come from the helpers' tighter
+  // `forecasts: ForecastEntry[]` and config shapes. Cast through
+  // `unknown` to keep tsc happy while preserving the runtime assumption.
   setupActionHandler(this as unknown as Parameters<typeof setupActionHandler>[0]);
   this._maybeApplyInitialScroll(changedProperties);
   setupScrollUx(this as unknown as Parameters<typeof setupScrollUx>[0]);
@@ -1155,7 +1153,7 @@ async updated(changedProperties: Map<PropertyKey, unknown>) {
 // merge via _refreshForecasts. Adding a new field that drives a source is
 // a one-line edit to the keys table, not a new branch in updated().
 //
-// Mode-toggle lazy-cache (#10): when only forecast.type changed and the
+// Mode-toggle lazy-cache: when only forecast.type changed and the
 // underlying recorder/subscribe fetch-key is the same (e.g. hourly↔today
 // share period='hour' and forecast_type='hourly'), no teardown is needed
 // at all — the displayed data is already correct, only the render-time
@@ -1595,10 +1593,9 @@ _formatSunshineHours(sunshine_duration: any, sunshine_duration_unit: any): numbe
   return formatSunshineHours(sunshine_duration, sunshine_duration_unit);
 }
 
-// Per-row template helpers. Extracted from the group renderers so each
-// row is a single conditional render — clearer than 4-row nested
-// ternaries and lets ESLint's no-nested-conditional rule apply at
-// per-row granularity (vs. the previous group-level miss).
+// Per-row template helpers. Each row is a single conditional render —
+// clearer than 4-row nested ternaries and lets ESLint's
+// no-nested-conditional rule apply at per-row granularity.
 
 _climateRow_humidity(show: boolean, humidity: unknown) {
   if (!show || humidity === undefined) return html``;
@@ -1822,13 +1819,11 @@ renderWind({ config, forecastItems } = this) {
   // forecast.show_wind_speed (numeric speed). The wind row appears
   // when either is on.
   //
-  // DEPRECATED: forecast.show_wind_forecast is a v1.x backwards-compat
-  // shim that still accepts `false` as a hard master-off so existing
-  // YAML configs that explicitly disabled the wind row keep working.
-  // New configs should use `show_wind_arrow: false` +
-  // `show_wind_speed: false` instead. Slated for removal in v2.0 — the
-  // editor never exposed it, so the install base for the explicit-false
-  // case is small.
+  // Deprecated: forecast.show_wind_forecast is a backwards-compat shim
+  // that still accepts `false` as a hard master-off so existing YAML
+  // configs that explicitly disabled the wind row keep working. New
+  // configs should use `show_wind_arrow: false` + `show_wind_speed:
+  // false` instead.
   const masterOff = config.forecast.show_wind_forecast === false;
   if (masterOff) return html``;
 

--- a/src/openmeteo-source.ts
+++ b/src/openmeteo-source.ts
@@ -288,9 +288,8 @@ export class OpenMeteoSunshineSource {
     return now - this._lastFetchMs >= REFRESH_TTL_MS;
   }
 
-  /** Subscribe a one-shot callback for refresh completion. Used by
-   *  main.js to call `requestUpdate` / `measureCard` once the data
-   *  lands. */
+  /** Subscribe a one-shot callback for refresh completion. Lets the
+   *  caller request an update / re-measure once the data lands. */
   setListener(cb: SunshineListener | null): void {
     this._listener = cb;
   }

--- a/src/scroll-ux.ts
+++ b/src/scroll-ux.ts
@@ -1,23 +1,12 @@
-// Scroll UX wiring for the forecast block.
+// Scroll UX wiring for the forecast block: drag-to-scroll on desktop,
+// left/right indicator chevrons, the jump-to-now floating button, the
+// leftmost / rightmost visible-date overlay at hourly mode, and the
+// indicator visibility tracking via the wrapper's scroll event.
 //
-// Lifted out of main.js in v1.1 — previously these were 4 methods
-// (_setupScrollUx, _updateScrollIndicators, _updateScrollDateStamps,
-// _onJumpToNowClick) plus inline @click bindings spread across
-// render markup. The module is the single source of truth for:
-//
-//   - mouse drag-to-scroll on desktop (touch falls through to native
-//     `overflow-x: auto` scroll; we only listen for movement-detection
-//     so a swipe doesn't also fire the card-level tap_action)
-//   - left/right indicator chevrons (one viewport step on click)
-//   - jump-to-now floating button (visible when scrolled noticeably
-//     away from the canonical "now" position; click smooth-scrolls
-//     back)
-//   - the leftmost / rightmost visible-date overlay at hourly mode
-//   - indicator visibility tracking via the wrapper's scroll event
-//
-// Coupling to the card instance: see `ScrollUxCard` interface below.
-// `_dragMoved` is shared with action-handler so a drag-to-scroll
-// suppresses the trailing tap.
+// Touch falls through to native `overflow-x: auto` scroll; we only
+// listen for movement-detection so a swipe doesn't also fire the
+// card-level tap_action. `_dragMoved` is shared with action-handler
+// so a drag-to-scroll suppresses the trailing tap.
 //
 // Idempotent on stable wrapper elements via a `_wsScrollUxBound`
 // flag — Lit reuses the wrapper across data refreshes, so re-binding

--- a/src/sunshine-source.ts
+++ b/src/sunshine-source.ts
@@ -1,14 +1,13 @@
 // Pure helpers for the sunshine-duration row.
 //
-// No DOM, no Home Assistant — just data shaping. The card calls these from
-// data-source.js (past tier) and main.js (post-processing pass that overlays
-// history / forecast attributes onto the merged forecast array).
+// No DOM, no Home Assistant — just data shaping for the past tier and
+// the post-processing pass that overlays history / forecast attributes
+// onto the merged forecast array.
 //
-// The decisions encoded here come from issue #6 (decision A1 = Variant A:
-// Methods F + C only; A2 = two slots; A3 = F2 forecast tier; A6 naming).
-// v1.7 added Method B2 (lux-derivation, #66): when no recorder sensor is
-// configured, derive the past-tier value from the illuminance sensor's
-// high-resolution history via the lux/clearsky_lux ratio.
+// The encoded decisions: Variant A (Methods F + C only) with two slots
+// and an F2 forecast tier. Method B2 (lux-derivation): when no recorder
+// sensor is configured, derive the past-tier value from the illuminance
+// sensor's high-resolution history via the lux/clearsky_lux ratio.
 
 import { clearSkyLuxFactory } from './condition-classifier.js';
 

--- a/src/utils/numeric.ts
+++ b/src/utils/numeric.ts
@@ -6,12 +6,6 @@
 // formatting. Returning null instead lets caller code use a single
 // `value == null` check to gate render branches.
 //
-// Used by:
-//   - main.js set hass for live "now" classifier inputs (8 sensor
-//     readouts per tick)
-//   - the live wind-direction parse where the sensor's state can be
-//     a numeric degree string OR a cardinal-name string ("N", "NW")
-//
 // Returns null for: undefined, null, "", "unknown", "unavailable",
 // "NaN", any non-numeric string, or a finite-check failure.
 export function parseNumericSafe(value: unknown): number | null {

--- a/src/utils/unit-converters.ts
+++ b/src/utils/unit-converters.ts
@@ -1,7 +1,4 @@
-// Pure unit-conversion helpers used by the live-attributes block in
-// `main.ts`. Extracted from the WeatherStationCard class in v1.10.1
-// so the conversion tables live alongside the leaf utilities and the
-// helpers themselves get direct unit-test coverage.
+// Pure unit-conversion helpers used by the live-attributes block.
 //
 // Wind / pressure tables are keyed by `targetUnit->sourceUnit`. Beaufort
 // and same-unit cases are short-circuited inside the converters and

--- a/src/weather-station-card-editor.ts
+++ b/src/weather-station-card-editor.ts
@@ -129,8 +129,8 @@ class WeatherStationCardEditor extends LitElement implements EditorLike {
     this.requestUpdate();
   };
 
-  // Chart-section ha-form handlers (v1.10.2 #87 migration). The chart
-  // section spans two config levels — top-level (title, days,
+  // Chart-section ha-form handlers. The chart section spans two
+  // config levels — top-level (title, days,
   // forecast_days) and forecast.* (number_of_forecasts, condition_icons,
   // show_*, style, round_temp, disable_animation). Each form replaces
   // the keys it owns and merges with the rest of config / forecast.
@@ -169,8 +169,8 @@ class WeatherStationCardEditor extends LitElement implements EditorLike {
     this.requestUpdate();
   };
 
-  // Live-panel ha-form handler (v1.10.2 #87 migration). Both forms
-  // (main panel toggles + attributes toggles) feed top-level cfg.show_*
+  // Live-panel ha-form handler. Both forms (main panel toggles +
+  // attributes toggles) feed top-level cfg.show_*
   // keys, so a single handler can merge whichever bag arrives. Same
   // diff/delete pattern as _chartTopChanged.
   _livePanelChanged = (event: Event): void => {
@@ -190,8 +190,8 @@ class WeatherStationCardEditor extends LitElement implements EditorLike {
     this.requestUpdate();
   };
 
-  // Per-section reset-to-defaults (v1.10.2 #92). Walks the
-  // SECTION_KEYS list for the given section and removes each key from
+  // Per-section reset-to-defaults. Walks the SECTION_KEYS list for
+  // the given section and removes each key from
   // this._config — letting DEFAULTS take over on the next render.
   // Dot-paths address nested keys (e.g. `forecast.show_sunshine`).
   // No confirm dialog: reset is reversible by closing the editor
@@ -393,8 +393,8 @@ class WeatherStationCardEditor extends LitElement implements EditorLike {
           border-bottom: 1px solid var(--divider-color);
         }
         h3.section:first-of-type { margin-top: 0; }
-        /* Section headers with the v1.10.2 reset-to-defaults icon
-           button. The button right-aligns in the heading; clicking it
+        /* Section headers with the reset-to-defaults icon button.
+           The button right-aligns in the heading; clicking it
            drops every key the section owns from this._config so DEFAULTS
            take over. */
         h3.section.section-header-with-reset {


### PR DESCRIPTION
## Summary

- Strips ~50 historical-scaffolding comments from `src/` per #125: version stamps (`v0.x` / `v1.x` / `since v…`), inline issue refs (`(#NN)`), extraction-history module headers (`Lifted out of main.js in v1.1`, `Extracted from … in v1.10.1`, `byte-identical to v0.8`), and the `Used by:` caller block in `utils/numeric.ts`.
- WHY-comments (HA quirks, threshold rationale, fallback decision trees, meteorological-source citations) are preserved. Mixed lines were rewritten to the WHY-only form (e.g. *"Same fan-out suppression as the station path above (#55)"* → *"Same fan-out suppression as the station path above"*).
- Module headers collapsed to ≤4-line responsibility statements per the issue's rule 4. No behaviour change, no API surface change, no test changes.

## Files touched

19 files in `src/` + rebuilt `dist/weather-station-card.js` (the only dist delta is one CSS template-literal comment in the editor that survived terser — same comment-edit reflected in the bundle). Net `-52` lines.

## Test plan

- [x] `npm run lint` → 0 errors (existing 59-warning backlog unchanged)
- [x] `npm run typecheck` → clean
- [x] `npm run test` → 531/531 passing
- [x] `npm run depcheck` → no violations (38 modules, 82 dependencies)
- [x] `npm run rollup` → builds; dist staged in sync

Closes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)