### PR TITLE
chore: gitignore .workflow/ artifacts from AI workflow skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ coverage/
 # Throwaway helper scripts used during a single editing session
 # (e.g. ESLint violation extractors during a sweep). Never shipped.
 .tmp-*
+# Phase artifacts from the AI workflow (~/.claude/skills/{brainstorm,grill-me,
+# plan-vertical,recap,verify-fix}). Transient — cleared at end of each task.
+.workflow/


### PR DESCRIPTION
## Summary

- Adds `.workflow/` to `.gitignore`. The local AI workflow skills (`brainstorm`, `grill-me`, `plan-vertical`, `recap`, `verify-fix` under `~/.claude/skills/`) write phase artifacts to `.workflow/<phase>.md` in the project root.
- Those files are transient — cleared at the end of each task — and never ship. Ignoring them prevents accidental commits during a multi-phase workflow.

## Test plan

- [x] `git status` no longer reports `.workflow/brainstorm.md` after creating one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)