### PR TITLE
docs(adr): tighten ADR-worthiness gate to AND-of-three filter

### DIFF
--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -61,11 +61,27 @@ When suggesting where information should live, use these targets:
 | `CHANGELOG.md` | Release-by-release log (every user-visible change is mentioned here) |
 | `CLAUDE.md` | Local-only context (gitignored). Do not propose ADR rationale to live here. |
 
+## Gating test — apply before proposing
+
+The activation triggers above are **detection signals**, not auto-suggestions. After a trigger fires, gate the proposal by the restrictive AND-of-three filter:
+
+1. **Hard to reverse** — the cost of changing the decision later is meaningful.
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **Result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons.
+
+**All three must be true.** If any one is missing, skip the ADR — the rationale belongs in a commit message, a code comment, the `CHANGELOG.md`, or simply in the diff itself.
+
+- Easy to reverse → just reverse it later.
+- Not surprising → nobody will wonder why.
+- No real alternative → "we did the obvious thing" isn't worth recording.
+
+This filter mirrors the one in the user-level `grill-with-docs` skill, so both stay aligned on what counts as ADR-worthy.
+
 ## Proactive prompting
 
-When an ADR-worthy change is detected, surface it before implementation, not after:
+When a trigger fires **and** the AND-of-three gate passes, surface it before implementation, not after:
 
-> This change introduces / modifies / adds X. That looks like a deliberate architectural choice with alternatives — should I draft an ADR for it before continuing?
+> This change introduces / modifies / adds X. That's a deliberate architectural choice with genuine alternatives and meaningful reversal cost — should I draft an ADR for it before continuing?
 >
 > Suggested: `docs/adr/NNNN-descriptive-title.md`.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,14 +6,22 @@ particular path was chosen and what alternatives were rejected.
 
 ## When to write one
 
-Write an ADR when a decision is:
+Write an ADR only when **all three** of these are true:
 
-- **Hard to reverse** — package upgrades, bundler swaps, public-API shape, data-source contracts.
-- **Surprising without context** — choices a future reader (or future Claude) would otherwise undo by accident.
-- **Cross-cutting** — touches multiple modules and can't be explained inside a single file's header comment.
+1. **Hard to reverse** — the cost of changing the decision later is meaningful (package upgrades, bundler swaps, public-API shape, data-source contracts).
+2. **Surprising without context** — a future reader (or future Claude) would otherwise undo it by accident, wondering "why on earth did they do it this way?".
+3. **Result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons.
+
+If any one is missing, skip the ADR:
+
+- Easy to reverse → just reverse it later.
+- Not surprising → nobody will wonder why.
+- No real alternative → "we did the obvious thing" isn't worth recording.
 
 Skip the ADR for routine bug fixes, refactors that don't change a contract, or
 decisions whose rationale already lives in the commit message.
+
+This restrictive AND-of-three test is enforced by the `documentation-guardian` skill and aligns with the user-level `grill-with-docs` skill.
 
 ## How to add one
 


### PR DESCRIPTION
## Summary

- `docs/adr/README.md` previously listed three properties (hard to reverse, surprising without context, cross-cutting) as if any one made an ADR worthwhile. Replace the implicit OR with an explicit AND-of-three filter.
- `.claude/skills/documentation/SKILL.md` (the `documentation-guardian` skill) gains the same gate as a check applied after a trigger fires, plus an updated proactive-prompt template that names the three conditions.
- Both files cross-reference each other and align with the user-level `grill-with-docs` skill so the bar for "ADR-worthy" stays consistent across surfaces.

## New gate

All three must hold:

1. **Hard to reverse** — the cost of changing the decision later is meaningful.
2. **Surprising without context** — a future reader will wonder "why on earth did they do it this way?".
3. **Result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons.

If any one is missing, the rationale belongs in a commit message, a code comment, the changelog, or just the diff.

## Test plan

- [x] Docs-only change — no code path touched, no unit/E2E gates to run.
- [x] Cross-references between the two files stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)