### PR TITLE
ci(perf): cold-mount perf regression gate (v2.0 slice 1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,35 +135,24 @@ jobs:
             test-results/
           retention-days: 14
 
-      - name: Render-time advisory summary
-        # Pulls test-results/perf-render-time.json (written by the
-        # tests-e2e/perf-render-time.spec.ts E2E spec) and renders it
-        # in the build summary. Advisory only — never fails the build,
-        # GHA-runner CPU variability would create false positives.
-        # Sustained regressions become visible as a trend in the
-        # summary line over multiple PRs.
-        if: ${{ always() }}
-        run: |
-          if [ ! -f test-results/perf-render-time.json ]; then
-            echo "perf-render-time.json missing (E2E may have failed before the spec ran)" >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          {
-            echo "## Render-time advisory"
-            echo ""
-            echo "End-to-end mount → chart-rendered timing for three representative configs (5 iterations each)."
-            echo ""
-            echo "| Scenario | Median (ms) | p95 (ms) |"
-            echo "|---|---:|---:|"
-            node -e "
-              const r = require('./test-results/perf-render-time.json');
-              for (const s of r.samples) {
-                console.log(\`| \${s.scenario} | \${s.median_ms} | \${s.p95_ms} |\`);
-              }
-            "
-            echo ""
-            echo "_Advisory only — not a CI gate. GHA-runner variability is high; track trends across PRs, not single-PR diffs._"
-          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Render-time perf gate
+        # Compares the per-scenario median mount → chart-rendered timing
+        # (written by tests-e2e/perf-render-time.spec.ts) against the
+        # committed perf-baseline.json + a generous +25% tolerance.
+        # A PR that measurably slows cold mount fails this step.
+        #
+        # Promoted from the former advisory-only summary in v2.0 slice 1
+        # (ADR-0014). The tolerance is deliberately generous: GHA-runner
+        # CPU variability is high (ADR-0003) and the spec already
+        # averages 5 iterations — the gate must catch real regressions,
+        # not noise. While perf-baseline.json carries `"placeholder":
+        # true` the gate is warn-only and prints the measured medians so
+        # the first master run can be used to pin real numbers.
+        #
+        # Not guarded by `if: always()` — when an earlier step fails the
+        # perf JSON is unreliable, and the gate's own exit code is what
+        # makes a regression fail the build.
+        run: node scripts/perf-gate.cjs
 
       - name: Verify committed bundle matches source
         # After ADR-0013 (ESM code-split) `dist/` holds a hashed-chunk

--- a/docs/QUALITY-GATES.md
+++ b/docs/QUALITY-GATES.md
@@ -133,6 +133,25 @@ target master directly. The current workflow dispatches on a
 feature branch and the bot pushes to that branch; a follow-up PR
 moves the baselines onto master.
 
+## Perf regression gate
+
+The `Render-time perf gate` step in `build` runs `scripts/perf-gate.cjs`,
+which compares the per-scenario median mount → chart-rendered timing from
+`tests-e2e/perf-render-time.spec.ts` against the committed
+`perf-baseline.json` plus a generous **+25 %** tolerance. A PR that
+measurably slows cold mount fails the build.
+
+The tolerance is deliberately wide — GHA-runner CPU variability is high
+(the same reason ADR-0003 pins visual baselines to the runner) and the
+spec already averages 5 iterations. The goal is to catch real
+regressions, not runner noise.
+
+Baseline numbers must be measured on the GHA runner, never locally.
+While `perf-baseline.json` carries `"placeholder": true` the gate is
+**warn-only**: it prints the measured medians to the step summary so the
+first `master` run can be used to pin real numbers. The full rationale
+is in [ADR-0014](adr/0014-perf-regression-gate.md).
+
 ## dist/ in sync
 
 The `verify dist matches HEAD` step in `build` re-runs the bundler in

--- a/docs/adr/0014-perf-regression-gate.md
+++ b/docs/adr/0014-perf-regression-gate.md
@@ -1,0 +1,136 @@
+# 0014: Cold-mount perf regression gate in CI
+
+**Status:** Accepted
+
+**Date:** 2026-05-20
+
+## Context
+
+`tests-e2e/perf-render-time.spec.ts` measures end-to-end mount →
+chart-rendered timing for three representative configs (`daily-`,
+`today-`, `hourly-combination`), averaging 5 iterations each, and
+writes `test-results/perf-render-time.json`. Until now the `build`
+workflow only **printed** those numbers into the run summary
+("Render-time advisory") — it never failed a build. A PR that
+measurably slowed cold mount produced a green check; the regression
+was only visible as a trend if someone happened to read the summary
+across several PRs.
+
+Cold mount is the recurring real-world case for this card (HA
+Companion app, fresh sessions re-pay the full mount), so a silent
+slowdown is a genuine user-facing regression. v2.0 pillar C wants
+this advisory promoted into a gate that fails the `build` job.
+
+The hard part is **noise**. Shared GHA `ubuntu-latest` runners vary
+in CPU allocation run-to-run. ADR-0003 already documents that the
+runner environment is variable enough that visual baselines must be
+pinned to it. A perf gate with a tight tolerance would produce
+false-red builds; too loose and it never fires. Two further problems:
+
+- **The baseline cannot be measured locally.** A dev laptop or WSL
+  renders at a different speed than the GHA runner — the same
+  argument ADR-0003 makes for visual baselines. A baseline committed
+  from a local run would be meaningless against a GHA assertion.
+- **Bootstrapping.** The very first commit that adds the gate has no
+  GHA-measured baseline to compare against.
+
+Alternatives considered:
+
+- **Keep it advisory-only.** Zero flakiness risk, but the plan
+  explicitly asks for a gate; a number nobody is forced to look at
+  does not guard slices 2–9.
+- **Tight tolerance (~+5–10%).** Would catch small regressions but
+  flake on runner noise — false-red builds erode trust in CI faster
+  than a missed 10% regression costs.
+- **Compare against the previous run instead of a committed
+  baseline.** Needs cross-run artifact storage and still drifts; a
+  committed baseline is reviewable in the diff and version-controlled.
+
+## Decision
+
+Promote the advisory step in `.github/workflows/build.yml` into a
+**hard gate** with a generous tolerance and a GHA-pinned baseline.
+
+- **`perf-baseline.json`** (repo root) holds the per-scenario baseline
+  medians, a `tolerance_pct` (set to **25**), and a `placeholder`
+  flag. Baseline numbers MUST be measured on the GHA `ubuntu-latest`
+  runner — never a local or WSL machine (same rationale as ADR-0003).
+
+- **`scripts/perf-gate.cjs`** is the gate. It reads
+  `test-results/perf-render-time.json` and `perf-baseline.json`,
+  compares each scenario's `median_ms` (p50) to
+  `baseline × (1 + tolerance_pct/100)`, emits `::error::` annotations,
+  and exits non-zero on a regression. Plain Node core, no
+  dependencies; its pure `evaluate()` core is unit-tested in
+  `tests/perf-gate.test.js`.
+
+- **Tolerance is +25%.** The spec already averages 5 iterations per
+  config; +25% over a GHA-measured baseline is wide enough to absorb
+  runner-noise variance yet still catches the kind of regression that
+  matters (a chart pipeline change that doubles mount time). This is
+  the deliberate "catch real regressions, not noise" trade.
+
+- **Placeholder bootstrap.** `perf-baseline.json` ships with
+  `"placeholder": true` and zeroed baselines. While that flag is set
+  the gate is **warn-only**: it prints the measured medians to the
+  step summary and a `::warning::`, and exits 0. The first `build`
+  run on `master` after this lands surfaces real GHA numbers; the
+  maintainer copies them into `perf-baseline.json`, sets
+  `"placeholder": false`, and opens a follow-up PR. From that PR on
+  the gate is armed and fails the build on a regression.
+
+- The gate step is **not** guarded by `if: always()`. When an earlier
+  step fails, the perf JSON is unreliable; and a missing JSON file is
+  itself treated as a gate failure (exit 2) so the gate can never go
+  green on absent data.
+
+## Consequences
+
+**Pros**
+
+- A PR that measurably slows cold mount → chart-rendered now fails
+  the required `build` check instead of printing a number nobody
+  reads. Slices 2–9 of v2.0 are guarded against silent perf drift.
+- The gate logic is a pure, unit-tested function — a regression in
+  the gate itself is caught by `tests/perf-gate.test.js`, not
+  discovered in production CI.
+- The baseline is a reviewable, version-controlled artifact: a PR
+  that re-pins it makes the new expectation explicit in the diff.
+- The placeholder mechanism means this PR can land without a
+  chicken-and-egg measurement problem and without any flakiness.
+
+**Cons**
+
+- The gate is inert (warn-only) until the follow-up PR pins real
+  numbers. There is a one-PR window where a regression would only
+  warn. Acceptable: the alternative is guessing baseline numbers.
+- A future GHA runner-image upgrade can shift all three baselines at
+  once (same failure mode ADR-0003 calls out). Recovery: re-pin
+  `perf-baseline.json` from a fresh `master` run.
+- +25% will not catch a small (~10–20%) regression. This is a
+  conscious trade against false-red builds — a tighter gate on a
+  noisy runner costs more trust than it saves.
+
+**Tradeoffs**
+
+- Advisory-only was rejected: the plan asks for an enforced gate.
+- A tight tolerance was rejected: runner noise would flake it.
+- Previous-run comparison was rejected: needs cross-run artifact
+  plumbing and is not reviewable; a committed baseline is both.
+- Per the feasibility escape in the slice brief, a warn-only
+  fallback was the documented safety net if a non-flaky hard gate
+  proved infeasible. It did not — the +25% tolerance plus 5-iteration
+  averaging makes a hard gate viable — so the gate ships armed
+  (after the placeholder is pinned), with the placeholder phase
+  acting as a built-in soft-launch rather than a permanent fallback.
+
+## Related
+
+- ADR-0003 (e2e baselines pinned to GHA) — same "the GHA runner is
+  the only valid measurement environment" rationale, applied here to
+  timing instead of pixels.
+- `tests-e2e/perf-render-time.spec.ts` — produces the JSON the gate
+  reads; its `samples[].median_ms` is the p50 metric compared.
+- `scripts/perf-gate.cjs` / `tests/perf-gate.test.js` — the gate and
+  its unit tests.
+- `.workflow/v2-direction/plan.md` — Slice 1 of the v2.0 plan.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,3 +57,4 @@ status line.
 - [0011 — Track `package-lock.json` for reproducible builds](./0011-track-package-lock.md) (Accepted)
 - [0012 — Chart library: uPlot](./0012-chart-library-uplot.md) (Accepted)
 - [0013 — ESM output with content-hashed chunks for lazy editor](./0013-esm-code-split-for-lazy-editor.md) (Accepted)
+- [0014 — Cold-mount perf regression gate in CI](./0014-perf-regression-gate.md) (Accepted)

--- a/perf-baseline.json
+++ b/perf-baseline.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Cold-mount perf regression baseline. See docs/adr/0014-perf-regression-gate.md. The 'placeholder' flag below makes the CI gate warn-only until real GHA-runner numbers are committed: the first 'build' run on master after this file lands prints the measured medians in its step summary -- copy them into 'baselines', set 'placeholder' to false, and open a follow-up PR. Numbers MUST come from the GHA ubuntu-latest runner (ADR-0003 rationale: a local/WSL machine renders at a different speed), never from a dev laptop.",
+  "placeholder": true,
+  "tolerance_pct": 25,
+  "metric": "median_ms",
+  "baselines": {
+    "daily-combination": 0,
+    "today-combination": 0,
+    "hourly-combination": 0
+  }
+}

--- a/scripts/perf-gate.cjs
+++ b/scripts/perf-gate.cjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+/*
+ * Cold-mount perf regression gate.
+ *
+ * Compares the per-scenario median mount -> chart-rendered timings
+ * produced by tests-e2e/perf-render-time.spec.ts against the committed
+ * baseline in perf-baseline.json, plus a generous tolerance.
+ *
+ * Invoked from the "Render-time perf gate" step in
+ * .github/workflows/build.yml. See docs/adr/0014-perf-regression-gate.md
+ * for the tolerance policy and the GHA-pinned-baseline rationale.
+ *
+ * Exit codes:
+ *   0  pass  -- every scenario is within baseline * (1 + tolerance);
+ *              also the warn-only path when the baseline is a placeholder.
+ *   1  fail  -- at least one scenario regressed past the tolerance.
+ *   2  error -- inputs missing or malformed (treated as a real failure:
+ *              a perf gate that cannot see its data must not go green).
+ *
+ * GHA annotations: `::error::` / `::warning::` / `::notice::` lines are
+ * emitted on stdout so they surface inline on the PR. A markdown block
+ * is appended to $GITHUB_STEP_SUMMARY when that env var is set.
+ *
+ * No external dependencies -- plain Node core so it runs before any
+ * `npm install` step too, and stays trivially unit-testable.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const BASELINE_PATH = path.join(REPO_ROOT, 'perf-baseline.json');
+const RESULTS_PATH = path.join(REPO_ROOT, 'test-results', 'perf-render-time.json');
+
+/** Append a markdown block to the GHA step summary, if running in CI. */
+function appendSummary(markdown) {
+  const file = process.env.GITHUB_STEP_SUMMARY;
+  if (!file) return;
+  try {
+    fs.appendFileSync(file, markdown + '\n');
+  } catch {
+    // Step summary is best-effort; never let it break the gate.
+  }
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+/**
+ * Core comparison. Pure -- takes parsed objects, returns a structured
+ * verdict. Kept side-effect-free so tests/perf-gate.test.js can drive it
+ * directly without touching the filesystem or process.exit.
+ *
+ * @param {object} baseline parsed perf-baseline.json
+ * @param {object} results  parsed test-results/perf-render-time.json
+ * @returns {{ status:'pass'|'fail'|'placeholder', rows:Array, messages:string[] }}
+ */
+function evaluate(baseline, results) {
+  const messages = [];
+  const tolerancePct =
+    typeof baseline.tolerance_pct === 'number' ? baseline.tolerance_pct : 25;
+  const factor = 1 + tolerancePct / 100;
+
+  const samples = Array.isArray(results.samples) ? results.samples : [];
+  if (samples.length === 0) {
+    return {
+      status: 'fail',
+      rows: [],
+      messages: ['perf-render-time.json contained no samples.'],
+    };
+  }
+
+  const baselines = baseline.baselines || {};
+  const placeholder = baseline.placeholder === true;
+
+  const rows = samples.map((s) => {
+    const measured = Number(s.median_ms);
+    const base = Number(baselines[s.scenario]);
+    const hasBaseline = Number.isFinite(base) && base > 0;
+    const limit = hasBaseline ? Math.round(base * factor * 100) / 100 : null;
+    const regressed = hasBaseline && Number.isFinite(measured) && measured > limit;
+    const deltaPct =
+      hasBaseline && Number.isFinite(measured)
+        ? Math.round(((measured - base) / base) * 1000) / 10
+        : null;
+    return {
+      scenario: s.scenario,
+      measured,
+      baseline: hasBaseline ? base : null,
+      limit,
+      deltaPct,
+      regressed,
+      hasBaseline,
+    };
+  });
+
+  // Placeholder mode: the committed baseline has not yet been pinned to
+  // real GHA numbers. Warn, print the measured medians so the maintainer
+  // can copy them into perf-baseline.json, but never fail the build.
+  if (placeholder) {
+    messages.push(
+      'perf-baseline.json is a placeholder -- perf gate is warn-only.',
+    );
+    return { status: 'placeholder', rows, messages };
+  }
+
+  const missing = rows.filter((r) => !r.hasBaseline).map((r) => r.scenario);
+  if (missing.length > 0) {
+    messages.push(
+      `No baseline entry for scenario(s): ${missing.join(', ')}. ` +
+        'Add them to perf-baseline.json.',
+    );
+  }
+
+  const regressions = rows.filter((r) => r.regressed);
+  const status = regressions.length > 0 ? 'fail' : 'pass';
+  return { status, rows, messages };
+}
+
+function fmt(n) {
+  return Number.isFinite(n) ? n.toFixed(2) : 'n/a';
+}
+
+function renderRows(rows) {
+  const lines = [
+    '| Scenario | Measured median (ms) | Baseline (ms) | Limit (+tol) | Delta |',
+    '|---|---:|---:|---:|---:|',
+  ];
+  for (const r of rows) {
+    const delta = r.deltaPct === null ? 'n/a' : `${r.deltaPct > 0 ? '+' : ''}${r.deltaPct}%`;
+    const mark = r.regressed ? ' ⚠️' : '';
+    lines.push(
+      `| ${r.scenario} | ${fmt(r.measured)} | ` +
+        `${r.baseline === null ? 'n/a' : fmt(r.baseline)} | ` +
+        `${r.limit === null ? 'n/a' : fmt(r.limit)} | ${delta}${mark} |`,
+    );
+  }
+  return lines.join('\n');
+}
+
+function main() {
+  // --- load inputs ---------------------------------------------------
+  if (!fs.existsSync(BASELINE_PATH)) {
+    console.log('::error::perf-baseline.json is missing at repo root.');
+    appendSummary('## Render-time perf gate\n\nperf-baseline.json missing.');
+    process.exit(2);
+  }
+  if (!fs.existsSync(RESULTS_PATH)) {
+    // The E2E spec writes this file in its afterAll hook. If it is
+    // absent the perf spec did not run -- a real failure for the gate
+    // (the surrounding E2E step would normally have failed first, but
+    // do not let the gate silently pass on missing data).
+    console.log(
+      '::error::test-results/perf-render-time.json missing -- ' +
+        'the perf-render-time E2E spec did not produce output.',
+    );
+    appendSummary(
+      '## Render-time perf gate\n\n' +
+        'perf-render-time.json missing -- E2E perf spec did not run.',
+    );
+    process.exit(2);
+  }
+
+  let baseline;
+  let results;
+  try {
+    baseline = readJson(BASELINE_PATH);
+    results = readJson(RESULTS_PATH);
+  } catch (err) {
+    console.log(`::error::Could not parse perf JSON inputs: ${err.message}`);
+    process.exit(2);
+  }
+
+  // --- evaluate ------------------------------------------------------
+  const verdict = evaluate(baseline, results);
+  const tolerancePct =
+    typeof baseline.tolerance_pct === 'number' ? baseline.tolerance_pct : 25;
+
+  // --- report --------------------------------------------------------
+  const summaryParts = ['## Render-time perf gate', ''];
+  summaryParts.push(
+    `Cold-mount mount → chart-rendered timing vs. committed baseline ` +
+      `(tolerance +${tolerancePct}%).`,
+    '',
+    renderRows(verdict.rows),
+    '',
+  );
+
+  if (verdict.status === 'placeholder') {
+    for (const m of verdict.messages) console.log(`::warning::${m}`);
+    console.log(
+      '::notice::Copy the measured medians above into perf-baseline.json, ' +
+        'set "placeholder": false, and open a follow-up PR to arm the gate.',
+    );
+    summaryParts.push(
+      '_Baseline is a **placeholder** — gate is warn-only. Copy the ' +
+        'measured medians into `perf-baseline.json`, set `"placeholder": ' +
+        'false`, and open a follow-up PR to arm the gate._',
+    );
+    appendSummary(summaryParts.join('\n'));
+    process.exit(0);
+  }
+
+  for (const m of verdict.messages) console.log(`::warning::${m}`);
+
+  if (verdict.status === 'fail') {
+    for (const r of verdict.rows.filter((x) => x.regressed)) {
+      console.log(
+        `::error::Perf regression in "${r.scenario}": median ` +
+          `${fmt(r.measured)} ms exceeds limit ${fmt(r.limit)} ms ` +
+          `(baseline ${fmt(r.baseline)} ms +${tolerancePct}% tolerance, ` +
+          `${r.deltaPct > 0 ? '+' : ''}${r.deltaPct}%).`,
+      );
+    }
+    summaryParts.push(
+      '',
+      '❌ **Perf gate failed** — at least one scenario regressed past ' +
+        'the tolerance. If this is an intentional, justified change, ' +
+        're-pin `perf-baseline.json` from a GHA run on `master`.',
+    );
+    appendSummary(summaryParts.join('\n'));
+    process.exit(1);
+  }
+
+  console.log('::notice::Perf gate passed — all scenarios within tolerance.');
+  summaryParts.push('', '✅ **Perf gate passed** — all scenarios within tolerance.');
+  appendSummary(summaryParts.join('\n'));
+  process.exit(0);
+}
+
+// Export the pure core for unit tests; only run when invoked directly.
+module.exports = { evaluate };
+
+if (require.main === module) {
+  main();
+}

--- a/tests/perf-gate.test.js
+++ b/tests/perf-gate.test.js
@@ -1,0 +1,141 @@
+// Unit tests for the cold-mount perf regression gate's pure core.
+//
+// The gate (scripts/perf-gate.cjs) is invoked from build.yml. Its
+// `evaluate()` function is side-effect-free: it takes a parsed baseline
+// + parsed perf results and returns a structured verdict. The I/O,
+// process.exit, and GHA annotation emission are the script's `main()`,
+// which is not exercised here -- only the comparison logic that decides
+// pass / fail / placeholder, since that is the part a regression in the
+// gate itself would silently break.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { evaluate } = require('../scripts/perf-gate.cjs');
+
+const SCENARIOS = ['daily-combination', 'today-combination', 'hourly-combination'];
+
+function results(medians) {
+  return {
+    samples: SCENARIOS.map((scenario, i) => ({
+      scenario,
+      median_ms: medians[i],
+      p95_ms: medians[i] * 1.2,
+      iterations: 5,
+    })),
+  };
+}
+
+function baseline(values, extra = {}) {
+  return {
+    placeholder: false,
+    tolerance_pct: 25,
+    metric: 'median_ms',
+    baselines: {
+      'daily-combination': values[0],
+      'today-combination': values[1],
+      'hourly-combination': values[2],
+    },
+    ...extra,
+  };
+}
+
+describe('perf-gate evaluate()', () => {
+  it('passes when every scenario is exactly on baseline', () => {
+    const v = evaluate(baseline([100, 80, 120]), results([100, 80, 120]));
+    expect(v.status).toBe('pass');
+    expect(v.rows.every((r) => !r.regressed)).toBe(true);
+  });
+
+  it('passes when scenarios are within the +25% tolerance', () => {
+    // 100 -> 124 is +24%, still inside the +25% band.
+    const v = evaluate(baseline([100, 80, 120]), results([124, 99, 149]));
+    expect(v.status).toBe('pass');
+  });
+
+  it('passes exactly at the tolerance boundary', () => {
+    // 100 * 1.25 = 125; measured 125 is not greater than the limit.
+    const v = evaluate(baseline([100, 80, 120]), results([125, 100, 150]));
+    expect(v.status).toBe('pass');
+  });
+
+  it('fails when a scenario regresses past the tolerance', () => {
+    // 100 -> 126 is +26%, past the +25% band.
+    const v = evaluate(baseline([100, 80, 120]), results([126, 80, 120]));
+    expect(v.status).toBe('fail');
+    const regressed = v.rows.filter((r) => r.regressed);
+    expect(regressed).toHaveLength(1);
+    expect(regressed[0].scenario).toBe('daily-combination');
+  });
+
+  it('reports the delta percentage on each row', () => {
+    const v = evaluate(baseline([100, 80, 120]), results([150, 80, 120]));
+    const daily = v.rows.find((r) => r.scenario === 'daily-combination');
+    expect(daily.deltaPct).toBe(50);
+  });
+
+  it('faster-than-baseline never fails the gate', () => {
+    const v = evaluate(baseline([100, 80, 120]), results([40, 30, 50]));
+    expect(v.status).toBe('pass');
+    const daily = v.rows.find((r) => r.scenario === 'daily-combination');
+    expect(daily.deltaPct).toBeLessThan(0);
+  });
+
+  it('honours a custom tolerance_pct', () => {
+    // With a tight 5% tolerance, 100 -> 110 regresses.
+    const v = evaluate(
+      baseline([100, 80, 120], { tolerance_pct: 5 }),
+      results([110, 80, 120]),
+    );
+    expect(v.status).toBe('fail');
+  });
+
+  it('defaults to a 25% tolerance when tolerance_pct is absent', () => {
+    const b = baseline([100, 80, 120]);
+    delete b.tolerance_pct;
+    expect(evaluate(b, results([124, 80, 120])).status).toBe('pass');
+    expect(evaluate(b, results([126, 80, 120])).status).toBe('fail');
+  });
+
+  it('treats a placeholder baseline as warn-only', () => {
+    const b = baseline([0, 0, 0], { placeholder: true });
+    // Even a wildly slow run does not fail when placeholder is set.
+    const v = evaluate(b, results([9999, 9999, 9999]));
+    expect(v.status).toBe('placeholder');
+    expect(v.messages.join(' ')).toMatch(/placeholder/i);
+  });
+
+  it('still records measured medians in placeholder mode', () => {
+    const b = baseline([0, 0, 0], { placeholder: true });
+    const v = evaluate(b, results([111, 222, 333]));
+    expect(v.rows.map((r) => r.measured)).toEqual([111, 222, 333]);
+  });
+
+  it('fails when the results file carries no samples', () => {
+    const v = evaluate(baseline([100, 80, 120]), { samples: [] });
+    expect(v.status).toBe('fail');
+    expect(v.messages.join(' ')).toMatch(/no samples/i);
+  });
+
+  it('warns but does not fail on a scenario missing from the baseline', () => {
+    const b = baseline([100, 80, 120]);
+    delete b.baselines['hourly-combination'];
+    const v = evaluate(b, results([100, 80, 120]));
+    // A missing baseline entry cannot be a regression -- it surfaces as
+    // a warning, not a hard fail, so adding a new scenario does not
+    // instantly red-build before its baseline is pinned.
+    expect(v.status).toBe('pass');
+    expect(v.messages.join(' ')).toMatch(/hourly-combination/);
+  });
+
+  it('treats a zero baseline (un-pinned) as a non-comparable entry', () => {
+    // placeholder:false but a scenario still left at 0 -- not a real
+    // baseline, so it must not be compared (0 * 1.25 = 0 would fail
+    // every run). It is reported as missing instead.
+    const b = baseline([100, 80, 0]);
+    const v = evaluate(b, results([100, 80, 200]));
+    expect(v.status).toBe('pass');
+    expect(v.messages.join(' ')).toMatch(/hourly-combination/);
+  });
+});


### PR DESCRIPTION
## What changed

Promotes the existing render-time **advisory** in the `build` workflow
into a **regression gate**. A PR that measurably slows the cold-mount
→ chart-rendered time now fails the CI `build` job instead of only
printing a number to the run summary.

- **`scripts/perf-gate.cjs`** (new) — reads
  `test-results/perf-render-time.json` (written by the existing
  `tests-e2e/perf-render-time.spec.ts`) and `perf-baseline.json`,
  compares each scenario's median (p50) to `baseline × (1 + tolerance)`,
  emits `::error::` annotations and exits non-zero on a regression.
  Plain Node core, no dependencies. Its pure `evaluate()` core is
  unit-tested.
- **`perf-baseline.json`** (new) — committed baseline medians, a `25`%
  tolerance, and a `placeholder` flag.
- **`tests/perf-gate.test.js`** (new) — 13 cases over the gate's pure
  core: on-baseline, within/at/past tolerance, faster-than-baseline,
  custom + default tolerance, placeholder mode, no-samples, missing /
  un-pinned (`0`) baseline entries.
- **`.github/workflows/build.yml`** — the former "Render-time advisory
  summary" step becomes "Render-time perf gate" running
  `node scripts/perf-gate.cjs`.
- **`docs/adr/0014-perf-regression-gate.md`** (new, Nygard format) —
  records the tolerance policy and the GHA-pinned-baseline rationale.
  Index + `docs/QUALITY-GATES.md` updated to match.

## Why

Cold mount is the recurring real-world case for this card (Companion
app, fresh sessions). A silent slowdown was a genuine user-facing
regression that produced a green check. Slice 1 of the v2.0 plan asks
for this advisory to become a gate so it guards slices 2–9.

## Tolerance and the placeholder bootstrap

The gate uses a **generous +25% tolerance**. GHA `ubuntu-latest`
runners vary in CPU allocation run-to-run (the same noise ADR-0003
cites for visual baselines); the spec already averages 5 iterations.
+25% is wide enough to absorb runner noise yet still catches a real
regression (a chart-pipeline change that doubles mount time).

The baseline **cannot be measured locally** — a dev/WSL machine
renders at a different speed than the GHA runner. To avoid guessing
numbers and to ship **zero flakiness risk**, `perf-baseline.json`
ships with `"placeholder": true` and zeroed baselines:

- While `placeholder` is set, the gate is **warn-only** — it prints the
  measured medians to the step summary and a `::warning::`, exits 0.
- The first `build` run on `master` after this lands surfaces real GHA
  numbers. The maintainer copies them into `perf-baseline.json`, sets
  `"placeholder": false`, and opens a one-line follow-up PR. From that
  PR on the gate is armed and fails the build on a regression.

This is a built-in soft-launch, not the feasibility-escape warn-only
fallback — a hard gate is viable here; it just needs one GHA run to
pin numbers it cannot get any other way. A missing perf JSON is
treated as a gate failure (exit 2) so the gate can never go green on
absent data.

## Build evidence

Run locally in the worktree:

- `npm run lint` — 0 errors (83 pre-existing backlog warnings)
- `npm run typecheck` — clean
- `npm test` — 26 files, 660 tests pass (includes the 13 new
  `perf-gate` cases)
- `npm run coverage` — thresholds hold (gate script is outside
  `src/`, not in coverage scope)
- `npm run depcheck` — no dependency violations
- `npm run rollup` — builds; `dist/` unchanged (no `src/` change, so
  the committed bundle stays in sync — "verify dist matches HEAD" will
  pass with nothing to rebuild)
- `node scripts/perf-gate.cjs` exercised directly: placeholder →
  exit 0 + warning; armed within tolerance → exit 0; armed past
  tolerance → exit 1 + `::error::`; missing results file → exit 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
