### PR TITLE
fix(readme): use valid HACS category=frontend in install button

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 </p>
 
 <p align="center">
-  <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=chriguschneider&category=dashboard&repository=weather-station-card"><img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Open in HACS" /></a>
+  <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=chriguschneider&category=frontend&repository=weather-station-card"><img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Open in HACS" /></a>
   &nbsp;·&nbsp;
   <a href="https://github.com/chriguschneider/weather-station-card/issues">Issues</a>
   &nbsp;·&nbsp;
@@ -165,7 +165,7 @@ button.
 
 ### HACS (Custom Repository)
 
-**One-click**: [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=chriguschneider&category=dashboard&repository=weather-station-card)
+**One-click**: [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=chriguschneider&category=frontend&repository=weather-station-card)
 
 Or manually:
 


### PR DESCRIPTION
## Summary
- The one-click HACS install button used `category=dashboard`, which is not a valid HACS category. HACS rejected the redirect with a pop-up error, forcing users to add the repository manually.
- Lovelace/frontend cards use `category=frontend` (same as Bubble Card; Mushroom omits the param entirely). Fixed both occurrences in `README.md` (badge row + one-click install link).

## Why
Reported on the community forum: a user clicked the GitHub install button, got a HACS pop-up error, and had to add the repo manually as a workaround. The wrong `category` value was the root cause.

## Test plan
- [ ] Click the "Open in HACS" badge / one-click link → HACS opens the repository dialog without an error pop-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)