### PR TITLE
fix(readme): cache downloads badge to survive shields.io token outages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/chriguschneider/weather-station-card/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/chriguschneider/weather-station-card?label=release" /></a>
   <a href="https://github.com/chriguschneider/weather-station-card/actions/workflows/build.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/chriguschneider/weather-station-card/build.yml?label=build" /></a>
   <a href="https://sonarcloud.io/summary/new_code?id=chriguschneider_weather-station-card"><img alt="Quality Gate Status" src="https://sonarcloud.io/api/project_badges/measure?project=chriguschneider_weather-station-card&metric=alert_status" /></a>
-  <a href="https://github.com/chriguschneider/weather-station-card/releases"><img alt="Total downloads" src="https://img.shields.io/github/downloads/chriguschneider/weather-station-card/total" /></a>
+  <a href="https://github.com/chriguschneider/weather-station-card/releases"><img alt="Total downloads" src="https://img.shields.io/github/downloads/chriguschneider/weather-station-card/total?cacheSeconds=86400" /></a>
   <a href="https://github.com/chriguschneider/weather-station-card/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/chriguschneider/weather-station-card?style=flat" /></a>
   <a href="https://github.com/chriguschneider/weather-station-card/commits/master"><img alt="Last commit" src="https://img.shields.io/github/last-commit/chriguschneider/weather-station-card" /></a>
   <a href="https://buymeacoffee.com/chriguschneider"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-FFDD00.svg" /></a>


### PR DESCRIPTION
## Summary
- The downloads badge intermittently rendered **"Unable to select next GitHub token from pool"** — a shields.io server-side error when its GitHub API token pool is temporarily exhausted, not a config issue on our side (the endpoint returns the correct count, e.g. 605, when healthy).
- Added `?cacheSeconds=86400` to the badge URL so shields.io serves the last good value for up to 24h during such outages instead of the error text.

## Test plan
- [ ] Badge renders the download count in the README on GitHub