### PR TITLE
ci(badges): self-host downloads/stars badges via endpoint JSON

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -1,0 +1,79 @@
+name: Badge metrics
+
+# Self-hosts the "downloads" and "stars" numbers so the README badges
+# don't depend on shields.io's shared GitHub-API token pool. That pool
+# is regularly exhausted ("Unable to select next GitHub token from
+# pool"), and GitHub's Camo image proxy then caches the broken SVG, so
+# the badges stay broken long after shields recovers.
+#
+# Instead we compute the numbers here with this repo's own GITHUB_TOKEN,
+# write two shields "endpoint" JSON files, and push them to a dedicated
+# orphan branch `badges`. The README points shields.io/endpoint at the
+# raw JSON, so shields only reads a static file and never calls the
+# GitHub API live — the token-pool error can't happen.
+
+on:
+  schedule:
+    # Daily at 04:17 UTC. Stars/downloads move slowly; once a day is plenty.
+    - cron: '17 4 * * *'
+  release:
+    # Refresh downloads right after a release ships new assets.
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: badge-metrics
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  metrics:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute metrics and write badge JSON
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          stars=$(gh api "repos/${REPO}" --jq '.stargazers_count')
+          downloads=$(gh api --paginate "repos/${REPO}/releases" \
+            --jq '[.[].assets[].download_count] | add // 0')
+
+          # Match shields' metric formatting: 1356 -> "1.4k", 2_300_000 -> "2.3M".
+          humanize() {
+            awk -v n="$1" 'BEGIN {
+              if (n >= 1000000) printf "%.1fM", n / 1000000;
+              else if (n >= 1000) printf "%.1fk", n / 1000;
+              else printf "%d", n;
+            }'
+          }
+
+          mkdir -p out
+          printf '{"schemaVersion":1,"label":"downloads","message":"%s","color":"brightgreen"}\n' \
+            "$(humanize "$downloads")" > out/downloads.json
+          printf '{"schemaVersion":1,"label":"stars","message":"%s","color":"blue"}\n' \
+            "$(humanize "$stars")" > out/stars.json
+
+          echo "stars=$stars downloads=$downloads"
+          cat out/downloads.json out/stars.json
+
+      - name: Publish to badges branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cd out
+          git init -q
+          git checkout -q -b badges
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add downloads.json stars.json
+          git commit -q -m "chore(badges): update metrics [skip ci]"
+          # Force-push a single-commit orphan: the branch only ever holds
+          # the two generated files, so no history is worth keeping.
+          git push -f "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" badges

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
   <a href="https://github.com/chriguschneider/weather-station-card/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/chriguschneider/weather-station-card?label=release" /></a>
   <a href="https://github.com/chriguschneider/weather-station-card/actions/workflows/build.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/chriguschneider/weather-station-card/build.yml?label=build" /></a>
   <a href="https://sonarcloud.io/summary/new_code?id=chriguschneider_weather-station-card"><img alt="Quality Gate Status" src="https://sonarcloud.io/api/project_badges/measure?project=chriguschneider_weather-station-card&metric=alert_status" /></a>
-  <a href="https://github.com/chriguschneider/weather-station-card/releases"><img alt="Total downloads" src="https://img.shields.io/github/downloads/chriguschneider/weather-station-card/total" /></a>
-  <a href="https://github.com/chriguschneider/weather-station-card/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/chriguschneider/weather-station-card?style=flat" /></a>
+  <a href="https://github.com/chriguschneider/weather-station-card/releases"><img alt="Total downloads" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fchriguschneider%2Fweather-station-card%2Fbadges%2Fdownloads.json" /></a>
+  <a href="https://github.com/chriguschneider/weather-station-card/stargazers"><img alt="Stars" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fchriguschneider%2Fweather-station-card%2Fbadges%2Fstars.json" /></a>
   <a href="https://github.com/chriguschneider/weather-station-card/commits/master"><img alt="Last commit" src="https://img.shields.io/github/last-commit/chriguschneider/weather-station-card" /></a>
   <a href="https://buymeacoffee.com/chriguschneider"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-FFDD00.svg" /></a>
   <a href="#ai-assisted-development"><img alt="AI Assisted" src="https://img.shields.io/badge/AI-assisted-2196F3.svg" /></a>


### PR DESCRIPTION
## Problem

The README **downloads** and **stars** badges render `Unable to select next GitHub token from pool` instead of a number.

Root cause is **not** this repo. Both badges used shields.io's live `github/downloads` / `github/stars` endpoints, which share a pool of GitHub API tokens on shields' hosted instance. That pool is regularly exhausted, so shields returns the error SVG — and GitHub's Camo image proxy caches that broken SVG, so the badges stay broken long after shields recovers. (The underlying data was always fine: 1356 downloads, 5 stars.)

`release` / `build` / `last-commit` survive by luck of which request grabbed a token.

## Fix

A scheduled workflow (`badges.yml`) computes both numbers with this repo's **own** `GITHUB_TOKEN` and force-pushes two shields [endpoint](https://shields.io/badges/endpoint-badge) JSON files to an orphan `badges` branch. The README now points `shields.io/endpoint` at the raw JSON, so shields only reads a static file and never calls the GitHub API live — the token-pool error becomes structurally impossible.

Triggers: daily cron, on release publish (refreshes downloads), and `workflow_dispatch`.

No PAT or Gist secret needed — the built-in `GITHUB_TOKEN` (with `contents: write`) creates and updates the `badges` branch. No commits land on `master`; the orphan branch only ever holds the two generated files.

## After merge

Dispatch the workflow once to create the `badges` branch and populate the JSON, then the endpoint badges go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)