### PR TITLE
ci(badges): self-host release and last-commit badges too

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -1,13 +1,14 @@
 name: Badge metrics
 
-# Self-hosts the "downloads" and "stars" numbers so the README badges
-# don't depend on shields.io's shared GitHub-API token pool. That pool
-# is regularly exhausted ("Unable to select next GitHub token from
-# pool"), and GitHub's Camo image proxy then caches the broken SVG, so
-# the badges stay broken long after shields recovers.
+# Self-hosts the README's GitHub-metric badges (downloads, stars,
+# release, last-commit) so they don't depend on shields.io's shared
+# GitHub-API token pool. That pool is regularly exhausted ("Unable to
+# select next GitHub token from pool"), and GitHub's Camo image proxy
+# then caches the broken SVG, so the badges stay broken long after
+# shields recovers.
 #
-# Instead we compute the numbers here with this repo's own GITHUB_TOKEN,
-# write two shields "endpoint" JSON files, and push them to a dedicated
+# Instead we compute the values here with this repo's own GITHUB_TOKEN,
+# write shields "endpoint" JSON files, and push them to a dedicated
 # orphan branch `badges`. The README points shields.io/endpoint at the
 # raw JSON, so shields only reads a static file and never calls the
 # GitHub API live — the token-pool error can't happen.
@@ -42,6 +43,9 @@ jobs:
           stars=$(gh api "repos/${REPO}" --jq '.stargazers_count')
           downloads=$(gh api --paginate "repos/${REPO}/releases" \
             --jq '[.[].assets[].download_count] | add // 0')
+          release=$(gh api "repos/${REPO}/releases/latest" --jq '.tag_name')
+          commit_date=$(gh api "repos/${REPO}/commits?per_page=1" \
+            --jq '.[0].commit.committer.date')
 
           # Match shields' metric formatting: 1356 -> "1.4k", 2_300_000 -> "2.3M".
           humanize() {
@@ -52,14 +56,33 @@ jobs:
             }'
           }
 
+          # last-commit is relative ("today" / "3 days ago"). The daily cron
+          # recomputes it from the real commit timestamp, so it self-corrects
+          # to within a day even with no new commits.
+          days=$(( ( $(date +%s) - $(date -d "$commit_date" +%s) ) / 86400 ))
+          if   [ "$days" -le 0 ]; then last_commit="today"
+          elif [ "$days" -eq 1 ]; then last_commit="yesterday"
+          else                         last_commit="${days} days ago"
+          fi
+          # Mirror shields' recency colouring: fresh = green, stale = amber.
+          if   [ "$days" -le 7 ];  then commit_color="brightgreen"
+          elif [ "$days" -le 30 ]; then commit_color="green"
+          elif [ "$days" -le 90 ]; then commit_color="yellow"
+          else                          commit_color="orange"
+          fi
+
           mkdir -p out
           printf '{"schemaVersion":1,"label":"downloads","message":"%s","color":"brightgreen"}\n' \
             "$(humanize "$downloads")" > out/downloads.json
           printf '{"schemaVersion":1,"label":"stars","message":"%s","color":"blue"}\n' \
             "$(humanize "$stars")" > out/stars.json
+          printf '{"schemaVersion":1,"label":"release","message":"%s","color":"blue"}\n' \
+            "$release" > out/release.json
+          printf '{"schemaVersion":1,"label":"last commit","message":"%s","color":"%s"}\n' \
+            "$last_commit" "$commit_color" > out/lastcommit.json
 
-          echo "stars=$stars downloads=$downloads"
-          cat out/downloads.json out/stars.json
+          echo "stars=$stars downloads=$downloads release=$release last_commit=$last_commit"
+          cat out/downloads.json out/stars.json out/release.json out/lastcommit.json
 
       - name: Publish to badges branch
         env:
@@ -72,8 +95,8 @@ jobs:
           git checkout -q -b badges
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add downloads.json stars.json
+          git add downloads.json stars.json release.json lastcommit.json
           git commit -q -m "chore(badges): update metrics [skip ci]"
           # Force-push a single-commit orphan: the branch only ever holds
-          # the two generated files, so no history is worth keeping.
+          # the generated badge files, so no history is worth keeping.
           git push -f "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" badges

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 <p align="center">
   <a href="LICENSE.md"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg" /></a>
   <a href="https://hacs.xyz/"><img alt="HACS Custom" src="https://img.shields.io/badge/HACS-Custom-orange.svg" /></a>
-  <a href="https://github.com/chriguschneider/weather-station-card/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/chriguschneider/weather-station-card?label=release" /></a>
+  <a href="https://github.com/chriguschneider/weather-station-card/releases/latest"><img alt="Latest release" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fchriguschneider%2Fweather-station-card%2Fbadges%2Frelease.json" /></a>
   <a href="https://github.com/chriguschneider/weather-station-card/actions/workflows/build.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/chriguschneider/weather-station-card/build.yml?label=build" /></a>
   <a href="https://sonarcloud.io/summary/new_code?id=chriguschneider_weather-station-card"><img alt="Quality Gate Status" src="https://sonarcloud.io/api/project_badges/measure?project=chriguschneider_weather-station-card&metric=alert_status" /></a>
   <a href="https://github.com/chriguschneider/weather-station-card/releases"><img alt="Total downloads" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fchriguschneider%2Fweather-station-card%2Fbadges%2Fdownloads.json" /></a>
   <a href="https://github.com/chriguschneider/weather-station-card/stargazers"><img alt="Stars" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fchriguschneider%2Fweather-station-card%2Fbadges%2Fstars.json" /></a>
-  <a href="https://github.com/chriguschneider/weather-station-card/commits/master"><img alt="Last commit" src="https://img.shields.io/github/last-commit/chriguschneider/weather-station-card" /></a>
+  <a href="https://github.com/chriguschneider/weather-station-card/commits/master"><img alt="Last commit" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fchriguschneider%2Fweather-station-card%2Fbadges%2Flastcommit.json" /></a>
   <a href="https://buymeacoffee.com/chriguschneider"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-FFDD00.svg" /></a>
   <a href="#ai-assisted-development"><img alt="AI Assisted" src="https://img.shields.io/badge/AI-assisted-2196F3.svg" /></a>
 </p>


### PR DESCRIPTION
## Why

Follow-up to #210. Right after the downloads/stars badges were migrated, the README's **release** and **last commit** badges were observed showing the exact same `Unable to select next GitHub token from pool` error — they used shields' live `github/v/release` and `github/last-commit` endpoints, which draw on the same exhausted shared-token pool. It's intermittent and rotates which badges it hits, so these two were next.

## What

- Workflow now also emits `release.json` and `lastcommit.json` to the `badges` branch.
- README's release + last-commit badges switched to `shields.io/endpoint` reading those files — no live GitHub API call, so the token-pool error is structurally impossible for them too.
- `last commit` stays relative (`today` / `N days ago`), recomputed on the daily cron so it self-corrects within a day; colour mirrors shields' recency shading (fresh = green → stale = amber).
- `release` reads the latest published release tag.

Shell logic (date math, humanize, colour buckets) was unit-checked locally across edge cases before pushing.

## After merge

Dispatch the workflow once so the `badges` branch gains the two new JSON files, then all four GitHub-metric badges are token-pool-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)