### PR TITLE
Opt-in agent automation (label agent:go + @claude)

### DIFF
--- a/.github/scripts/pick-model.sh
+++ b/.github/scripts/pick-model.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Pick the Claude model for an issue from its labels.
+#
+# Explicit override wins: an `agent:opus` / `agent:sonnet` / `agent:haiku`
+# label forces that model. Otherwise fall back to priority labels, else the
+# default. (This repo has no P1/P2/P3 labels, so most issues resolve to the
+# default Sonnet unless you add an explicit agent:* label.)
+#
+#   agent:opus   -> claude-opus-4-8
+#   agent:sonnet -> claude-sonnet-4-6
+#   agent:haiku  -> claude-haiku-4-5
+#   P1           -> claude-opus-4-8
+#   P3 / good first issue -> claude-haiku-4-5
+#   (default)    -> claude-sonnet-4-6
+#
+# Usage: pick-model.sh <issue-number>. Prints `model=<id>` on stdout.
+set -euo pipefail
+
+issue="${1:?usage: pick-model.sh <issue-number>}"
+labels="$(gh issue view "$issue" --json labels --jq '[.labels[].name] | join(",")')"
+
+model="claude-sonnet-4-6" # default workhorse
+case ",$labels," in
+  *,agent:opus,*)                  model="claude-opus-4-8" ;;
+  *,agent:haiku,*)                 model="claude-haiku-4-5" ;;
+  *,agent:sonnet,*)                model="claude-sonnet-4-6" ;;
+  *,P1,*)                          model="claude-opus-4-8" ;;
+  *,P3,* | *,"good first issue",*) model="claude-haiku-4-5" ;;
+esac
+
+echo "issue #$issue labels=[$labels] -> $model" >&2
+echo "model=$model"

--- a/.github/workflows/claude-labeled.yml
+++ b/.github/workflows/claude-labeled.yml
@@ -1,0 +1,80 @@
+name: Claude (opt-in via label)
+
+# Opt-in automation: an issue is worked ONLY when it carries the `agent:go`
+# label. Ideas / discussions without the label are never touched. Add the
+# label to hand an issue to Claude; it implements it and opens a DRAFT PR.
+# Never merges, never pushes to master. Requires the CLAUDE_CODE_OAUTH_TOKEN
+# secret. See docs/agent-automation.md.
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Issue number to work on"
+        required: true
+
+jobs:
+  work-issue:
+    # Only when the label just added is agent:go (or a manual dispatch).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' && github.event.label.name == 'agent:go')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write # claude-code-action needs OIDC for its GitHub App token
+    concurrency:
+      group: claude-issue-${{ github.event.issue.number || github.event.inputs.issue }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Pick model
+        id: model
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          n="${{ github.event.issue.number || github.event.inputs.issue }}"
+          bash .github/scripts/pick-model.sh "$n" >> "$GITHUB_OUTPUT"
+
+      - name: Implement and open a draft PR
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Headless worker: allow git / gh / npm. Safe: isolated runner,
+          # master is branch-protected, draft PRs only.
+          claude_args: "--model ${{ steps.model.outputs.model }} --max-turns 40 --dangerously-skip-permissions"
+          prompt: |
+            You are working, unattended, on GitHub issue
+            #${{ github.event.issue.number || github.event.inputs.issue }}
+            of this repository. Read AGENTS.md, ARCHITECTURE.md and docs/adr/
+            FIRST and follow them; the repo-local commit-guardian /
+            documentation-guardian skills apply.
+
+            Rules (non-negotiable):
+            - Work on a branch `claude/<issue>-<short-slug>`. NEVER push to master.
+            - This is a TypeScript repo with real gates. Run `npm ci`, then
+              `npm run build` (lint + typecheck + vitest + coverage) and make it
+              pass before opening the PR. If you changed `src/`, rebuild the
+              committed bundle with `npm run build` (dist is committed, ADR-0001).
+            - Do NOT regenerate E2E visual baselines locally — they are pinned to
+              the GHA runner (ADR-0003). Leave `tests-e2e/snapshots/` untouched;
+              the CI job owns them.
+            - Open a **draft** PR against master with `gh pr create --draft`,
+              `Closes #${{ github.event.issue.number || github.event.inputs.issue }}`,
+              summarising the change and how you verified it.
+            - If the issue is ambiguous or you cannot verify the fix, DO NOT
+              guess: open the draft PR with your partial work and a clear
+              "Blocked / needs decision" section, and stop.
+
+      - name: Release the label on failure
+        if: failure() && github.event_name == 'issues'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh issue edit "${{ github.event.issue.number }}" --remove-label "agent:go" || true

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -1,0 +1,37 @@
+name: Claude (@mention)
+
+# Write "@claude ..." in an issue or PR comment and Claude works that item.
+# Complements the opt-in label flow (claude-labeled.yml). Draft PRs only,
+# never master. Requires the CLAUDE_CODE_OAUTH_TOKEN secret.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    concurrency:
+      group: claude-mention-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Pick model
+        id: model
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          n="${{ github.event.issue.number || github.event.pull_request.number }}"
+          bash .github/scripts/pick-model.sh "$n" >> "$GITHUB_OUTPUT"
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model ${{ steps.model.outputs.model }} --max-turns 20 --dangerously-skip-permissions"

--- a/docs/agent-automation.md
+++ b/docs/agent-automation.md
@@ -1,0 +1,39 @@
+# Agent automation (opt-in)
+
+Unlike a backlog that gets ground through automatically, this repo is
+idea-driven: **only issues you explicitly hand over are worked by Claude.**
+Both flows open **draft PRs only** and never push to `master`
+(branch protection enforces it).
+
+## Opt-in by label (`claude-labeled.yml`)
+
+Add the **`agent:go`** label to an issue → Claude implements it on a
+`claude/<n>-<slug>` branch and opens a draft PR. Issues without the label
+(ideas, discussions, `enhancement` you haven't triaged) are never touched.
+
+- Start it: `gh issue edit <n> --add-label agent:go` (or add the label in the UI).
+- Manually: Actions → "Claude (opt-in via label)" → Run workflow → issue number.
+- If the run fails, the `agent:go` label is removed so it doesn't look claimed.
+
+## On @claude mention (`claude-mention.yml`)
+
+Write `@claude ...` in an issue or PR comment to have Claude work that item.
+
+## Model per issue
+
+`.github/scripts/pick-model.sh` chooses the model from labels. This repo has
+no P1/P2/P3, so add an explicit override when it matters:
+
+| Label | Model |
+|---|---|
+| `agent:opus` | `claude-opus-4-8` |
+| `agent:sonnet` | `claude-sonnet-4-6` |
+| `agent:haiku` | `claude-haiku-4-5` |
+| (none) | `claude-sonnet-4-6` (default) |
+
+## Setup (maintainer, one-time)
+
+Install the Claude GitHub App and add the repo secret
+`CLAUDE_CODE_OAUTH_TOKEN` (`claude setup-token`). The agent reads AGENTS.md
+and the ADRs, and does not regenerate the GHA-pinned E2E baselines
+(ADR-0003).


### PR DESCRIPTION
Idea-driven repo, so **no backlog grind**: Claude works an issue only when it carries the **`agent:go`** label (or on an `@claude` mention). Draft PRs only, never master.

- `pick-model.sh` with `agent:opus/sonnet/haiku` overrides (no P-levels here; default Sonnet).
- `claude-labeled.yml` (opt-in) + `claude-mention.yml`.
- `docs/agent-automation.md`.
- Prompt follows AGENTS.md/ADRs and leaves the GHA-pinned E2E baselines (ADR-0003) alone.

Needs repo secret `CLAUDE_CODE_OAUTH_TOKEN` before the Claude step runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)