### PR TITLE
Security: gate @claude on author role

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -12,7 +12,12 @@ on:
 
 jobs:
   claude:
-    if: contains(github.event.comment.body, '@claude')
+    # Only the owner / collaborators can trigger this. Comment events carry
+    # secrets even from strangers, so gate the @claude path on author role.
+    if: >-
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+               github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Comment events carry repo secrets even for non-collaborators, so a stranger could trigger the agent via `@claude` on this public repo. Restrict the `@claude` path to `OWNER`/`MEMBER`/`COLLABORATOR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)