### PR TITLE
fix(ci): Claude workflows check out without persisted credentials

### DIFF
--- a/.github/workflows/claude-labeled.yml
+++ b/.github/workflows/claude-labeled.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Pick model

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -29,6 +29,8 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Pick model
         id: model
         env:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Review, fix (bounded), decide


### PR DESCRIPTION
Same fix as chriguschneider/hass-meteoswiss-weather#27: actions/checkout v6+ stores GITHUB_TOKEN in an includeIf credentials file that claude-code-action does not clear, so agent pushes go out as github-actions[bot] and their CI runs wait for approval. persist-credentials: false on the Claude workflows' checkout steps; harmless on v4, required once dependabot bumps checkout.