### PR TITLE
docs(readme): say which stations the card works with

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ forecast — driven by sensor data, not a `weather.*` entity.
 ## What this card does
 
 Most Lovelace weather cards visualise a forecast served by a `weather.*`
-entity. If you actually run a weather station on-site (Shelly Plus H&T,
-BTHome, ESPHome, Pirateweather receiver, …), the more interesting view is
-*what happened over the past N days* — and the most useful "now" panel
-reflects the live readings of those same sensors. This card does both:
+entity. If you actually run a weather station on-site, the more interesting
+view is *what happened over the past N days* — and whether the forecast got
+it right — while the most useful "now" panel reflects the live readings of
+those same sensors. This card does both:
 
 - A **past chart** with high / low temperature curves and daily
   precipitation bars, plus an icon row of the worst-of-day weather
@@ -91,6 +91,15 @@ reflects the live readings of those same sensors. This card does both:
 Conditions are derived by a deterministic, meteorologically-grounded
 classifier (see [docs/CONDITIONS.md](docs/CONDITIONS.md#how-conditions-are-determined)
 — every threshold is tied to a WMO / NWS / AMS / IES source).
+
+**Works with any station that reaches Home Assistant as sensors.** The card
+never asks which hardware you own — it reads plain `sensor.*` entities, so an
+Ecowitt gateway, a WeatherFlow Tempest, Netatmo, Froggit, Davis, Ambient
+Weather, BTHome sensors, a Shelly Plus H&T or your own ESPHome build all feed
+it the same way. Stations that publish rain rate and daily total as separate
+entities can wire both, and solar-irradiance sensors (W/m²) work in the
+illuminance slot alongside lux. A `weather.*` entity is optional — you only
+need one for the forecast half of the chart.
 
 ## Modes and chart resolutions
 


### PR DESCRIPTION
Prose-only README change that was sitting uncommitted in the working tree during the v2.4.1 release; kept out of that PR because it is unrelated to the sunshine-row removal.

## Why

The intro named four examples in a parenthesis (Shelly Plus H&T, BTHome, ESPHome, Pirateweather) and left it there. Someone running an Ecowitt gateway or a Tempest had no way to tell from the README whether this card was for them — when the real answer is that the question doesn't apply, because the card reads plain `sensor.*` entities and never asks what produced them.

## What changes

- The hardware list moves out of the intro into its own paragraph, with the brands people actually search for, and states the rule behind it instead of just listing names.
- Mentions the two capabilities that come up when people check compatibility: separate rain-rate / daily-total entities (`sensors.precipitation_rate`, #253) and solar-irradiance sensors in the illuminance slot (v2.2.3).
- States that a `weather.*` entity is optional — the intro implied it but never said it.
- The intro gains "and whether the forecast got it right", which is the reason the past chart and the forecast share one axis.

Claims were checked against the code before committing: the two precipitation slots, irradiance in `sensors.illuminance`, and the weather-entity requirement all match what `setConfig`'s completeness check and `docs/CONFIGURATION.md` say today.

No images, no structural change, no `<picture>`/`<source>` — plain prose only.

## Note

HACS renders `README.md` in the store info panel from master, so this appears there on merge rather than waiting for the next tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
